### PR TITLE
daemon: carry the previous statuses through a backend scan failure

### DIFF
--- a/daemon/cache.go
+++ b/daemon/cache.go
@@ -128,6 +128,18 @@ func (c *cache) publish(all []VMStatus, healthy bool, degraded int, at time.Time
 	}
 }
 
+func (c *cache) byBackend(backend string) []VMStatus {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	var out []VMStatus
+	for _, st := range c.order {
+		if st.Backend == backend {
+			out = append(out, st)
+		}
+	}
+	return out
+}
+
 func (c *cache) snapshot() ([]VMStatus, health) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/daemon/reconcile.go
+++ b/daemon/reconcile.go
@@ -21,6 +21,7 @@ func (d *Daemon) reconcile(ctx context.Context) {
 		// Only a scan failure is unhealthy: a restart fixes an unreadable store, not a VM nobody can converge.
 		if err != nil {
 			healthy = false
+			st = d.state.byBackend(b.Type())
 		}
 		degraded += failed
 		all = append(all, st...)

--- a/daemon/reconcile_test.go
+++ b/daemon/reconcile_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -18,6 +19,23 @@ func TestReconcileConvergesDeadRunningRecord(t *testing.T) {
 
 	if len(f.converged) != 1 || f.converged[0] != (convergeCall{vmID: "vm1", gen: 7}) {
 		t.Fatalf("got %+v, want one convergence fenced on generation 7", f.converged)
+	}
+}
+
+func TestReconcileScanFailureKeepsPublishedStatuses(t *testing.T) {
+	f := newFake().put(runningRec("vm1", 1))
+	d := newTestDaemon(t, f)
+	d.reconcile(t.Context())
+
+	f.scanErr = errors.New("store unreadable")
+	d.reconcile(t.Context())
+
+	statuses, h := d.state.snapshot()
+	if h.ok {
+		t.Error("health ok after a scan failure")
+	}
+	if len(statuses) != 1 || statuses[0].ID != "vm1" {
+		t.Fatalf("got %+v, want the previous pass's vm1 carried forward", statuses)
 	}
 }
 


### PR DESCRIPTION
## Problem

`Daemon.reconcile` appends whatever `reconcileBackend` returns and publishes unconditionally. On a scan failure `reconcileBackend` returns `nil` statuses, so `cache.publish` diffed every VM of that backend as `DELETED` and `GET /v1/vms` answered `200` without them; only `/healthz` flipped, and neither the list nor the SSE stream is gated on it.

## Change

When a backend's scan fails, `reconcile` republishes that backend's statuses from the previous pass (`cache.byBackend`) and keeps `healthy=false`. The API contract becomes "stale but present" instead of "silently gone".

## Evidence

- `TestReconcileScanFailureKeepsPublishedStatuses`: pass 1 publishes `vm1`; pass 2 with `scanErr` set keeps `vm1` in the snapshot and reports unhealthy. Without the change the same test reports `got [], want the previous pass's vm1 carried forward`.
- `GOWORK=off make lint` (linux + darwin): 0 issues ×2. `make fmt-check`: clean. `asl ./daemon/...` both GOOS: clean. `go test -race ./daemon/`: green.