### PR TITLE
perf: remember a filesystem without reflink and say so once

### DIFF
--- a/hypervisor/disks.go
+++ b/hypervisor/disks.go
@@ -123,7 +123,7 @@ func PrepareOCICOW(ctx context.Context, cowPath string, storage int64, storageCo
 
 func copyPairs(ctx context.Context, pairs [][2]string, sync utils.SyncMode) error {
 	_, err := utils.Map(ctx, pairs, func(_ context.Context, _ int, p [2]string) (struct{}, error) {
-		if err := utils.ReflinkCopy(p[0], p[1], sync); err != nil {
+		if err := utils.ReflinkCopy(ctx, p[0], p[1], sync); err != nil {
 			return struct{}{}, fmt.Errorf("copy %s: %w", filepath.Base(p[1]), err)
 		}
 		return struct{}{}, nil

--- a/snapshot/localfile/export.go
+++ b/snapshot/localfile/export.go
@@ -54,7 +54,7 @@ func (lf *LocalFile) ExportToDir(ctx context.Context, ref, dir string) error {
 	}
 	// Fan out: snapshot dirs hold a few large files (memory, COW, data disks), so wall time is the longest copy, not the sum.
 	if _, err = utils.Map(ctx, names, func(_ context.Context, _ int, name string) (struct{}, error) {
-		if copyErr := utils.ReflinkCopy(filepath.Join(dir, name), filepath.Join(dataDir, name), utils.Sync); copyErr != nil {
+		if copyErr := utils.ReflinkCopy(ctx, filepath.Join(dir, name), filepath.Join(dataDir, name), utils.Sync); copyErr != nil {
 			return struct{}{}, fmt.Errorf("copy %s: %w", name, copyErr)
 		}
 		return struct{}{}, nil

--- a/utils/reflink_linux.go
+++ b/utils/reflink_linux.go
@@ -3,18 +3,37 @@
 package utils
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"sync"
 	"syscall"
+
+	"github.com/projecteru2/core/log"
 )
 
 // ficlone is the ioctl number for btrfs/xfs/bcachefs CoW file cloning.
 const ficlone = 0x40049409
 
+// noReflink remembers the filesystems whose FICLONE answered "not supported", so later copies on them skip the create/ioctl/unlink round trip.
+var noReflink sync.Map
+
 // ReflinkCopy copies a single file, preferring FICLONE (O(1) CoW on btrfs/xfs/bcachefs) and falling back to SparseCopy on any error.
-func ReflinkCopy(dst, src string, sync SyncMode) error {
-	if err := tryFiclone(dst, src, sync); err == nil {
+func ReflinkCopy(ctx context.Context, dst, src string, sync SyncMode) error {
+	fs, known := fsID(filepath.Dir(dst))
+	if _, unsupported := noReflink.Load(fs); known && unsupported {
+		return SparseCopy(dst, src, sync)
+	}
+	err := tryFiclone(dst, src, sync)
+	if err == nil {
 		return nil
+	}
+	if known && reflinkUnsupported(err) {
+		if _, seen := noReflink.LoadOrStore(fs, struct{}{}); !seen {
+			log.WithFunc("utils.ReflinkCopy").Warnf(ctx, "reflink unsupported on the filesystem holding %s (%v); clones copy their disks in full", filepath.Dir(dst), err)
+		}
 	}
 	return SparseCopy(dst, src, sync)
 }
@@ -32,4 +51,17 @@ func tryFiclone(dst, src string, sync SyncMode) error {
 		}
 		return nil
 	})
+}
+
+func fsID(dir string) (syscall.Fsid, bool) {
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(dir, &st); err != nil {
+		return syscall.Fsid{}, false
+	}
+	return st.Fsid, true
+}
+
+// reflinkUnsupported is true for the errnos a filesystem returns when it has no FICLONE at all, never for a per-file or cross-device failure.
+func reflinkUnsupported(err error) bool {
+	return errors.Is(err, syscall.EOPNOTSUPP) || errors.Is(err, syscall.ENOTTY)
 }

--- a/utils/reflink_linux_test.go
+++ b/utils/reflink_linux_test.go
@@ -1,0 +1,29 @@
+//go:build linux
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReflinkCopyCachesAnUnsupportedFilesystem(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.WriteFile(src, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ReflinkCopy(t.Context(), filepath.Join(dir, "dst"), src, NoSync); err != nil {
+		t.Fatalf("ReflinkCopy: %v", err)
+	}
+	fs, ok := fsID(dir)
+	if !ok {
+		t.Fatal("statfs failed on the temp dir")
+	}
+	_, cached := noReflink.Load(fs)
+	unsupported := reflinkUnsupported(tryFiclone(filepath.Join(dir, "probe"), src, NoSync))
+	if cached != unsupported {
+		t.Fatalf("cache says unsupported=%v, a fresh FICLONE says unsupported=%v", cached, unsupported)
+	}
+}

--- a/utils/reflink_other.go
+++ b/utils/reflink_other.go
@@ -2,7 +2,9 @@
 
 package utils
 
+import "context"
+
 // ReflinkCopy copies a single file. On non-Linux, falls back to SparseCopy.
-func ReflinkCopy(dst, src string, sync SyncMode) error {
+func ReflinkCopy(_ context.Context, dst, src string, sync SyncMode) error {
 	return SparseCopy(dst, src, sync)
 }

--- a/utils/reflink_test.go
+++ b/utils/reflink_test.go
@@ -117,7 +117,7 @@ func TestReflinkCopy_DstDirNotExist(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := ReflinkCopy(filepath.Join(dir, "nodir", "dst"), src, Sync)
+	err := ReflinkCopy(t.Context(), filepath.Join(dir, "nodir", "dst"), src, Sync)
 	if err == nil {
 		t.Fatal("expected error for nonexistent dst directory")
 	}

--- a/utils/reflink_test.go
+++ b/utils/reflink_test.go
@@ -17,7 +17,7 @@ func TestReflinkCopy_BasicContent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ReflinkCopy(dst, src, Sync); err != nil {
+	if err := ReflinkCopy(t.Context(), dst, src, Sync); err != nil {
 		t.Fatalf("ReflinkCopy: %v", err)
 	}
 
@@ -39,7 +39,7 @@ func TestReflinkCopy_EmptyFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ReflinkCopy(dst, src, Sync); err != nil {
+	if err := ReflinkCopy(t.Context(), dst, src, Sync); err != nil {
 		t.Fatalf("ReflinkCopy: %v", err)
 	}
 
@@ -62,7 +62,7 @@ func TestReflinkCopy_LargeFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ReflinkCopy(dst, src, Sync); err != nil {
+	if err := ReflinkCopy(t.Context(), dst, src, Sync); err != nil {
 		t.Fatalf("ReflinkCopy: %v", err)
 	}
 
@@ -89,7 +89,7 @@ func TestReflinkCopy_OverwritesExisting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ReflinkCopy(dst, src, NoSync); err != nil {
+	if err := ReflinkCopy(t.Context(), dst, src, NoSync); err != nil {
 		t.Fatalf("ReflinkCopy: %v", err)
 	}
 
@@ -104,7 +104,7 @@ func TestReflinkCopy_OverwritesExisting(t *testing.T) {
 
 func TestReflinkCopy_SrcNotExist(t *testing.T) {
 	dir := t.TempDir()
-	err := ReflinkCopy(filepath.Join(dir, "dst"), filepath.Join(dir, "nonexistent"), Sync)
+	err := ReflinkCopy(t.Context(), filepath.Join(dir, "dst"), filepath.Join(dir, "nonexistent"), Sync)
 	if err == nil {
 		t.Fatal("expected error for nonexistent src")
 	}
@@ -133,7 +133,7 @@ func TestReflinkCopy_PreservesSize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ReflinkCopy(dst, src, Sync); err != nil {
+	if err := ReflinkCopy(t.Context(), dst, src, Sync); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
ReflinkCopy tried FICLONE on every disk copy and fell back to SparseCopy silently, so on an ext4 root every clone paid a create, ioctl and unlink for nothing and the operator never learned that clones copy their disks in full (audit item cocoon-host D1).

- The destination directory's filesystem id is cached the first time FICLONE answers EOPNOTSUPP or ENOTTY; later copies on that filesystem skip the attempt. Only those two errnos mark a filesystem: a cross-device or per-file failure still falls back without poisoning the cache.
- One warning per filesystem names the directory and the errno.
- ReflinkCopy takes the caller's context for that log; both in-repo callers already had one.
- Linux test: after one copy in a temp dir, the cache agrees with a fresh FICLONE on the same directory (holds on ext4, tmpfs, btrfs and xfs alike). Run on the .79 Linux host (ext4): PASS.

Consumers: cocoon-macos calls `utils.ReflinkCopy` at two sites (`cmd/vm/datadisk.go`, `cmd/vm/utils.go`); they gain the context argument when cocoon-macos next bumps its cocoon pin.

Hot path: one statfs per disk copy on the clone path (a few µs) and, on a reflink-less filesystem, three syscalls fewer per copy.