### PR TITLE
cut: network Inspect/List and batch Delete, Reserver hard-require; images stop importing meta/json

### DIFF
--- a/cmd/core/metastore.go
+++ b/cmd/core/metastore.go
@@ -73,8 +73,8 @@ func MetaJSONNamespaces(conf *config.Config) []metajson.Namespace {
 		{Name: hypervisor.VMNamespaceName(string(config.HypervisorCloudHypervisor)), FilePath: chCfg.IndexFile(), LockPath: chCfg.IndexLock(), Codec: vmTables},
 		{Name: hypervisor.VMNamespaceName(string(config.HypervisorFirecracker)), FilePath: fcCfg.IndexFile(), LockPath: fcCfg.IndexLock(), Codec: vmTables},
 		{Name: localfile.NamespaceName, FilePath: snapCfg.IndexFile(), LockPath: snapCfg.IndexLock(), Codec: snapTables},
-		oci.NewConfig(conf.RootDir, 0).JSONNamespace(),
-		cloudimg.NewConfig(conf.RootDir, 0).JSONNamespace(),
+		imageJSONNamespace(&oci.NewConfig(conf.RootDir, 0).BaseConfig),
+		imageJSONNamespace(&cloudimg.NewConfig(conf.RootDir, 0).BaseConfig),
 		cni.NewConfig(conf).JSONNamespace(),
 		{
 			Name:     metalog.NamespaceName,
@@ -166,4 +166,16 @@ func openSQLiteStore(ctx context.Context, conf *config.Config, dbPath string) (m
 		return nil, err
 	}
 	return s, nil
+}
+
+func imageJSONNamespace(c *images.BaseConfig) metajson.Namespace {
+	return metajson.Namespace{
+		Name:     c.Name,
+		FilePath: c.IndexFile(),
+		LockPath: c.IndexLock(),
+		Codec: metajson.TableCodec{Specs: []metajson.TableSpec{
+			{Key: "images", Table: images.TableRecords},
+			{Key: tombstone.TableName, Table: tombstone.TableName, Optional: true},
+		}},
+	}
 }

--- a/cmd/core/network.go
+++ b/cmd/core/network.go
@@ -102,8 +102,7 @@ func (n *NetProviders) Cleanup(ctx context.Context, vmID string) error {
 		// Lazy CNI; OK to skip for bridge-only setups.
 		return nil
 	}
-	_, err = p.Delete(ctx, []string{vmID})
-	return err
+	return p.Delete(ctx, vmID)
 }
 
 // cniOnly resolves the CNI provider without a VM record, for the ID-only teardown path.

--- a/cmd/vm/run.go
+++ b/cmd/vm/run.go
@@ -523,7 +523,7 @@ func pinResolvedBlobs(ctx context.Context, backends []imagebackend.Images, ref s
 func prereserveVM(ctx context.Context, hyper hypervisor.Hypervisor, vmID string, vmCfg *types.VMConfig, blobIDs map[string]struct{}) (rollback, unlock func(), err error) {
 	r, ok := hyper.(hypervisor.Reserver)
 	if !ok {
-		return func() {}, func() {}, nil
+		return nil, nil, fmt.Errorf("hypervisor %s cannot reserve VM ids", hyper.Type())
 	}
 	unlock, err = r.LockVMOps(ctx, vmID)
 	if err != nil {
@@ -602,7 +602,7 @@ func rollbackNetwork(ctx context.Context, netProvider network.Network, vmID stri
 	// Survive Ctrl-C, bounded so a hung plugin can't wedge the CLI; an aborted rollback keeps its records for GC retry.
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), rollbackTimeout)
 	defer cancel()
-	if _, delErr := netProvider.Delete(ctx, []string{vmID}); delErr != nil {
+	if delErr := netProvider.Delete(ctx, vmID); delErr != nil {
 		log.WithFunc("cmd.vm.rollbackNetwork").Warnf(ctx, "rollback network for %s: %v", vmID, delErr)
 	}
 }

--- a/images/baseconfig.go
+++ b/images/baseconfig.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	metajson "github.com/cocoonstack/cocoon/meta/json"
-	"github.com/cocoonstack/cocoon/meta/tombstone"
 	"github.com/cocoonstack/cocoon/utils"
 )
 
@@ -30,19 +28,6 @@ func (c *BaseConfig) BlobLockPath(hex string) string {
 
 func (c *BaseConfig) IndexFile() string { return filepath.Join(c.DBDir(), "images.json") }
 func (c *BaseConfig) IndexLock() string { return filepath.Join(c.DBDir(), "images.lock") }
-
-// JSONNamespace is an image backend's json meta namespace.
-func (c *BaseConfig) JSONNamespace() metajson.Namespace {
-	return metajson.Namespace{
-		Name:     c.Name,
-		FilePath: c.IndexFile(),
-		LockPath: c.IndexLock(),
-		Codec: metajson.TableCodec{Specs: []metajson.TableSpec{
-			{Key: "images", Table: TableRecords},
-			{Key: tombstone.TableName, Table: tombstone.TableName, Optional: true},
-		}},
-	}
-}
 
 func (c *BaseConfig) BlobPath(hex string) string {
 	return filepath.Join(c.BlobsDir(), hex+c.BlobExt)

--- a/network/bridge/bridge_linux.go
+++ b/network/bridge/bridge_linux.go
@@ -145,18 +145,9 @@ func (b *Bridge) Remove(_ context.Context, vmID string, indices ...int) error {
 func (b *Bridge) Quiesce(_ context.Context, _ string) error   { return nil }
 func (b *Bridge) Unquiesce(_ context.Context, _ string) error { return nil }
 
-func (b *Bridge) Delete(_ context.Context, vmIDs []string) ([]string, error) {
-	return CleanupTAPs(b.tapPrefix, vmIDs), nil
-}
-
-// Inspect: bridge has no persistent records.
-func (b *Bridge) Inspect(_ context.Context, _ string) (*types.Network, error) {
-	return nil, nil
-}
-
-// List: bridge has no persistent records.
-func (b *Bridge) List(_ context.Context) ([]*types.Network, error) {
-	return nil, nil
+func (b *Bridge) Delete(_ context.Context, vmID string) error {
+	CleanupTAPs(b.tapPrefix, []string{vmID})
+	return nil
 }
 
 // RegisterGC reclaims orphan bridge TAP devices.

--- a/network/bridge/bridge_other.go
+++ b/network/bridge/bridge_other.go
@@ -42,12 +42,6 @@ func (b *Bridge) Add(_ context.Context, _ string, _ *types.VMConfig, _ ...networ
 	return nil, errUnsupported
 }
 
-func (b *Bridge) Delete(_ context.Context, _ []string) ([]string, error) { return nil, errUnsupported }
-
-func (b *Bridge) Inspect(_ context.Context, _ string) (*types.Network, error) {
-	return nil, errUnsupported
-}
-
-func (b *Bridge) List(_ context.Context) ([]*types.Network, error) { return nil, errUnsupported }
+func (b *Bridge) Delete(_ context.Context, _ string) error { return errUnsupported }
 
 func CleanupTAPs(_ string, _ []string) []string { return nil }

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -45,7 +45,7 @@ type CNI struct {
 	loadErr     error
 }
 
-// New creates a CNI provider; conflist loading is best-effort so Delete/Inspect/List still work when none are available — Add fails in that case.
+// New creates a CNI provider; conflist loading is best-effort so Delete still works when none is available — Add fails in that case.
 func New(conf *config.Config, store meta.Store) (*CNI, error) {
 	if conf == nil {
 		return nil, fmt.Errorf("config is nil")

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cocoonstack/cocoon/meta"
 	"github.com/cocoonstack/cocoon/network"
 	"github.com/cocoonstack/cocoon/types"
-	"github.com/cocoonstack/cocoon/utils"
 )
 
 const typ = "cni"
@@ -97,30 +96,6 @@ func (c *CNI) Verify(_ context.Context, vmID string, expected []*types.NetworkCo
 	return nil
 }
 
-// Inspect returns the network record for id, or (nil, nil) if not found.
-func (c *CNI) Inspect(ctx context.Context, id string) (*types.Network, error) {
-	var result *types.Network
-	return result, c.view(ctx, func(t *netTx) error {
-		rec, err := t.Get(id)
-		if err != nil || rec == nil {
-			return err
-		}
-		result = &rec.Network
-		return nil
-	})
-}
-
-// List returns all known network records.
-func (c *CNI) List(ctx context.Context) ([]*types.Network, error) {
-	var result []*types.Network
-	return result, c.view(ctx, func(t *netTx) error {
-		return t.Scan(func(_ string, rec *networkRecord) error {
-			result = append(result, &rec.Network)
-			return nil
-		})
-	})
-}
-
 // Quiesce brings the VM's host-side veths down so a stopped VM's TC redirect stops storming softirqs against its now-carrier-less TAP (mirred-to-down-device). The netns and TAP are kept for a fast restart, which Unquiesce re-enables.
 func (c *CNI) Quiesce(ctx context.Context, vmID string) error {
 	return c.setLinkState(ctx, vmID, false)
@@ -131,12 +106,9 @@ func (c *CNI) Unquiesce(ctx context.Context, vmID string) error {
 	return c.setLinkState(ctx, vmID, true)
 }
 
-// Delete tears down each VM's networking; the caller already holds the VM lock, so this never re-locks the non-reentrant flock.
-func (c *CNI) Delete(ctx context.Context, vmIDs []string) ([]string, error) {
-	result := utils.ForEach(ctx, vmIDs, func(ctx context.Context, vmID string) error {
-		return c.teardownProtocol(ctx, vmID, nil, false)
-	})
-	return result.Succeeded, result.Err()
+// Delete tears down the VM's networking; the caller already holds the VM lock, so this never re-locks the non-reentrant flock.
+func (c *CNI) Delete(ctx context.Context, vmID string) error {
+	return c.teardownProtocol(ctx, vmID, nil, false)
 }
 
 // tearDownNICs runs CNI DEL (+ optional TAP delete) on every record, returning the fully-torn-down record IDs (the caller's sweep set) and the joined failures.

--- a/network/network.go
+++ b/network/network.go
@@ -26,9 +26,7 @@ type Network interface {
 	Remove(ctx context.Context, vmID string, indices ...int) error
 	Quiesce(ctx context.Context, vmID string) error
 	Unquiesce(ctx context.Context, vmID string) error
-	Delete(context.Context, []string) ([]string, error)
-	Inspect(context.Context, string) (*types.Network, error)
-	List(context.Context) ([]*types.Network, error)
+	Delete(ctx context.Context, vmID string) error
 	RegisterGC(*gc.Orchestrator)
 }
 


### PR DESCRIPTION
Three commits from the 2026-09-02 audit ledger (cocoon-host A1, A2, hypervisor A1, images C1); no behavior change on the happy path.

1. `Network.Inspect` and `Network.List` had no caller; `Network.Delete` took a slice while both callers pass one VM id and paid `ForEach` for it. `Delete(ctx, vmID) error`; bridge and CNI shrink to match.
2. Both backends implement `hypervisor.Reserver`, so the `!ok` branch in `prereserveVM` never ran; had it run it would have skipped the ops lock and let GC see an ownerless netns. It is an error now.
3. `images/baseconfig.go` imported `meta/json` and `meta/tombstone` only to describe its namespace for the json engine, a domain→engine edge; `cmd/core` already assembles every other namespace and now assembles these two from the `BaseConfig` paths.

Gates: `make lint` 0 issues both GOOS, `make fmt-check`, `asl ./...` both GOOS, `go test -race` on network, cmd and images.