### PR TITLE
review: whole-repo round — relaxed snapshot touch, pidfd wait, dead Scan path, cloud-image sniff, FindVM reuse, comment budget

### DIFF
--- a/cgroup/cgroup_test.go
+++ b/cgroup/cgroup_test.go
@@ -219,7 +219,7 @@ func TestReconcileFenceCanonicalEquality(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(parent, "cpuset.cpus"), []byte("0-7\n"), 0o600); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
-	// No cpuset.cpus.effective fixture exists: reaching checkSubset would fail, so success proves the parsed-set gate short-circuited.
+
 	if err := reconcileFence(parent, "0-3,4-7"); err != nil {
 		t.Errorf("canonically-equal fence rewrote: %v", err)
 	}

--- a/cmd/core/metastore.go
+++ b/cmd/core/metastore.go
@@ -73,8 +73,8 @@ func MetaJSONNamespaces(conf *config.Config) []metajson.Namespace {
 		{Name: hypervisor.VMNamespaceName(string(config.HypervisorCloudHypervisor)), FilePath: chCfg.IndexFile(), LockPath: chCfg.IndexLock(), Codec: vmTables},
 		{Name: hypervisor.VMNamespaceName(string(config.HypervisorFirecracker)), FilePath: fcCfg.IndexFile(), LockPath: fcCfg.IndexLock(), Codec: vmTables},
 		{Name: localfile.NamespaceName, FilePath: snapCfg.IndexFile(), LockPath: snapCfg.IndexLock(), Codec: snapTables},
-		imageJSONNamespace(&oci.NewConfig(conf.RootDir, 0).BaseConfig),
-		imageJSONNamespace(&cloudimg.NewConfig(conf.RootDir, 0).BaseConfig),
+		ImageJSONNamespace(&oci.NewConfig(conf.RootDir, 0).BaseConfig),
+		ImageJSONNamespace(&cloudimg.NewConfig(conf.RootDir, 0).BaseConfig),
 		cni.NewConfig(conf).JSONNamespace(),
 		{
 			Name:     metalog.NamespaceName,
@@ -154,6 +154,19 @@ func CloseMetaStore(ctx context.Context) {
 	}
 }
 
+// ImageJSONNamespace describes an image store's json namespace from its base paths.
+func ImageJSONNamespace(c *images.BaseConfig) metajson.Namespace {
+	return metajson.Namespace{
+		Name:     c.Name,
+		FilePath: c.IndexFile(),
+		LockPath: c.IndexLock(),
+		Codec: metajson.TableCodec{Specs: []metajson.TableSpec{
+			{Key: "images", Table: images.TableRecords},
+			{Key: tombstone.TableName, Table: tombstone.TableName, Optional: true},
+		}},
+	}
+}
+
 // openSQLiteStore opens the sqlite engine, bootstrapping a fresh root or repairing a crashed bootstrap; a legacy json root never bootstraps — that would shadow its data.
 func openSQLiteStore(ctx context.Context, conf *config.Config, dbPath string) (meta.Store, error) {
 	if !LegacyJSONPresent(conf) {
@@ -166,16 +179,4 @@ func openSQLiteStore(ctx context.Context, conf *config.Config, dbPath string) (m
 		return nil, err
 	}
 	return s, nil
-}
-
-func imageJSONNamespace(c *images.BaseConfig) metajson.Namespace {
-	return metajson.Namespace{
-		Name:     c.Name,
-		FilePath: c.IndexFile(),
-		LockPath: c.IndexLock(),
-		Codec: metajson.TableCodec{Specs: []metajson.TableSpec{
-			{Key: "images", Table: images.TableRecords},
-			{Key: tombstone.TableName, Table: tombstone.TableName, Optional: true},
-		}},
-	}
 }

--- a/cmd/core/utils_test.go
+++ b/cmd/core/utils_test.go
@@ -20,10 +20,10 @@ func TestSanitizeVMName(t *testing.T) {
 		{"ghcr.io/foo/ubuntu:24.04", "cocoon-foo-ubuntu-24.04"},
 		{"localhost:5000/myimg:latest", "cocoon-myimg"},
 		{"library/nginx:1.25", "cocoon-nginx-1.25"},
-		// Digest refs: tag/digest should be stripped, only repo kept.
+
 		{"ghcr.io/ns/img@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "cocoon-ns-img"},
 		{"ubuntu@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "cocoon-ubuntu"},
-		// No tag, no digest — "latest" is implicit and omitted.
+
 		{"ghcr.io/org/repo", "cocoon-org-repo"},
 		{"alpine", "cocoon-alpine"},
 	}
@@ -38,7 +38,6 @@ func TestSanitizeVMName(t *testing.T) {
 }
 
 func TestSanitizeVMName_Truncation(t *testing.T) {
-	// Build an image ref that would produce a name > 63 chars.
 	long := "ghcr.io/" + strings.Repeat("a", 80) + ":latest"
 	got := sanitizeVMName(long)
 	if len(got) > 63 {
@@ -136,7 +135,7 @@ func TestNormalizeDataDiskSpecs(t *testing.T) {
 		if err := normalizeDataDiskSpecs(specs); err != nil {
 			t.Fatal(err)
 		}
-		// First auto picks data2 (data1 taken by spec[1]).
+
 		if specs[0].Name != "data2" {
 			t.Errorf("specs[0].Name = %q, want data2", specs[0].Name)
 		}

--- a/cmd/images/commands.go
+++ b/cmd/images/commands.go
@@ -41,7 +41,7 @@ Multiple FILE arguments are treated as split qcow2 parts or multiple tar layers.
 		Args:  cobra.MinimumNArgs(1),
 		RunE:  h.Pull,
 	}
-	pullCmd.Flags().Bool("force", false, "bypass cache and always re-download (useful when a mutable tag was replaced upstream)")
+	pullCmd.Flags().Bool("force", false, "re-download a cloud-image URL whose content was replaced upstream (OCI tags are re-resolved on every pull)")
 
 	imageCmd.AddCommand(
 		pullCmd,

--- a/cmd/meta/convert/convert_test.go
+++ b/cmd/meta/convert/convert_test.go
@@ -90,7 +90,6 @@ func TestResumeClaimsCommittedTarget(t *testing.T) {
 	spec := testSpec(t, "vms")
 	seedJSON(t, spec, "vms")
 
-	// Crash window: target fully committed, manifest not yet marked done.
 	src, err := openSource(spec, "sqlite")
 	if err != nil {
 		t.Fatalf("open source: %v", err)
@@ -221,7 +220,6 @@ func TestCrashRerunMatrix(t *testing.T) {
 				spec := testSpec(t, "vms")
 				seedJSON(t, spec, "vms")
 				if target == "json" {
-					// Reverse direction starts from a sqlite store.
 					if err := Run(t.Context(), spec, "sqlite"); err != nil {
 						t.Fatalf("forward convert: %v", err)
 					}
@@ -264,7 +262,7 @@ func TestCrashRerunMatrix(t *testing.T) {
 func TestDistinctGenerationsRoundTrip(t *testing.T) {
 	ctx := t.Context()
 	spec := testSpec(t, "vms")
-	// Two committed generations: main and .prev are DISTINCT (§9).
+
 	js, err := metajson.Open(spec.JSON...)
 	if err != nil {
 		t.Fatal(err)
@@ -294,7 +292,6 @@ func TestDistinctGenerationsRoundTrip(t *testing.T) {
 		t.Fatalf("convert back to json: %v", err)
 	}
 
-	// Corrupt the new main: the served generation must be the imported one, never a stranded pre-conversion .prev (§9).
 	main, err := os.ReadFile(spec.JSON[0].FilePath)
 	if err != nil {
 		t.Fatal(err)
@@ -312,7 +309,6 @@ func TestDistinctGenerationsRoundTrip(t *testing.T) {
 	}
 }
 
-// TestUncheckpointedWALReverseConversion: a commit stranded in the WAL by a killed process must survive the checkpoint-then-aside reverse conversion (§9).
 func TestUncheckpointedWALReverseConversion(t *testing.T) {
 	if testing.Short() {
 		t.Skip("multi-process gate skipped in -short")
@@ -362,7 +358,6 @@ func TestUncheckpointedWALReverseConversion(t *testing.T) {
 	}
 }
 
-// TestWALWriterWorker commits one durable record, acks, and hangs until killed so the WAL is never checkpointed by a clean close.
 func TestWALWriterWorker(t *testing.T) {
 	db := os.Getenv("META_MP_DB")
 	if db == "" {
@@ -384,7 +379,6 @@ func TestWALWriterWorker(t *testing.T) {
 	select {} //nolint:staticcheck // hang until SIGKILL keeps the WAL un-checkpointed
 }
 
-// TestConvertSkipsNeverWrittenNamespace: a namespace whose lock dir was never created (subsystem never ran) must not fail the quiesce probe.
 func TestConvertSkipsNeverWrittenNamespace(t *testing.T) {
 	spec := testSpec(t, "vms")
 	seedJSON(t, spec, "vms")

--- a/cmd/snapshot/handler.go
+++ b/cmd/snapshot/handler.go
@@ -28,14 +28,9 @@ func (h Handler) Save(cmd *cobra.Command, args []string) error {
 	logger := log.WithFunc("cmd.snapshot.Save")
 
 	vmRef := args[0]
-	hyper, err := cmdcore.FindHypervisor(ctx, conf, vmRef)
+	hyper, vm, err := cmdcore.FindVM(ctx, conf, vmRef)
 	if err != nil {
 		return fmt.Errorf("find VM %s: %w", vmRef, err)
-	}
-	// Pin the inspected ID: a same-name delete+recreate between resolve and capture would snapshot the impostor.
-	vm, err := hyper.Inspect(ctx, vmRef)
-	if err != nil {
-		return fmt.Errorf("inspect VM %s: %w", vmRef, err)
 	}
 	snapBackend, err := cmdcore.InitSnapshot(ctx, conf)
 	if err != nil {
@@ -63,13 +58,9 @@ func (h Handler) List(cmd *cobra.Command, _ []string) error {
 	vmRef, _ := cmd.Flags().GetString("vm")
 	var filterIDs map[string]struct{}
 	if vmRef != "" {
-		hyper, hyperErr := cmdcore.FindHypervisor(ctx, conf, vmRef)
-		if hyperErr != nil {
-			return hyperErr
-		}
-		vm, inspectErr := hyper.Inspect(ctx, vmRef)
-		if inspectErr != nil {
-			return fmt.Errorf("inspect VM %s: %w", vmRef, inspectErr)
+		_, vm, findErr := cmdcore.FindVM(ctx, conf, vmRef)
+		if findErr != nil {
+			return findErr
 		}
 		filterIDs = vm.SnapshotIDs
 		if len(filterIDs) == 0 {

--- a/cmd/vm/exec_test.go
+++ b/cmd/vm/exec_test.go
@@ -77,9 +77,7 @@ func TestReadHybridVsockReply(t *testing.T) {
 	}
 }
 
-// TestDialHybridVsock_ConnectHandshake drives the CH/FC hybrid vsock dialect (CONNECT <port>\n → OK <port>\n) against an in-process listener.
 func TestDialHybridVsock_ConnectHandshake(t *testing.T) {
-	// macOS caps unix socket paths at ~104 bytes and t.TempDir() can overflow it, so use os.CreateTemp + immediate unlink.
 	f, err := os.CreateTemp("", "vsock-*.uds")
 	if err != nil {
 		t.Fatalf("create temp: %v", err)

--- a/cmd/vm/handler.go
+++ b/cmd/vm/handler.go
@@ -15,13 +15,9 @@ type Handler struct {
 }
 
 func (h Handler) resolveRunningVM(ctx context.Context, conf *config.Config, op, ref string) (*types.VM, error) {
-	hyper, err := cmdcore.FindHypervisor(ctx, conf, ref)
+	_, info, err := cmdcore.FindVM(ctx, conf, ref)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", op, err)
-	}
-	info, err := hyper.Inspect(ctx, ref)
-	if err != nil {
-		return nil, fmt.Errorf("%s: inspect: %w", op, err)
 	}
 	if info.State != types.VMStateRunning {
 		return nil, fmt.Errorf("%s: %w", op, hypervisor.ErrNotRunning)

--- a/cmd/vm/hibernate.go
+++ b/cmd/vm/hibernate.go
@@ -18,18 +18,13 @@ func (h Handler) Hibernate(cmd *cobra.Command, args []string) error {
 	logger := log.WithFunc("cmd.vm.hibernate")
 	vmRef := args[0]
 
-	hyper, err := cmdcore.FindHypervisor(ctx, conf, vmRef)
+	hyper, vm, err := cmdcore.FindVM(ctx, conf, vmRef)
 	if err != nil {
 		return fmt.Errorf("find VM %s: %w", vmRef, err)
 	}
 	hib, ok := hyper.(hypervisor.Hibernator)
 	if !ok {
 		return fmt.Errorf("backend %s does not support hibernate", hyper.Type())
-	}
-	// Pin the inspected ID: a same-name delete+recreate between resolve and pause would hibernate the impostor.
-	vm, err := hyper.Inspect(ctx, vmRef)
-	if err != nil {
-		return fmt.Errorf("inspect VM %s: %w", vmRef, err)
 	}
 	snapBackend, err := cmdcore.InitSnapshot(ctx, conf)
 	if err != nil {

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -77,12 +77,7 @@ func (h Handler) Stop(cmd *cobra.Command, args []string) error {
 func (h Handler) Inspect(cmd *cobra.Command, args []string) error {
 	ctx, conf := h.Init(cmd)
 
-	hyper, err := cmdcore.FindHypervisor(ctx, conf, args[0])
-	if err != nil {
-		return fmt.Errorf("inspect: %w", err)
-	}
-
-	info, err := hyper.Inspect(ctx, args[0])
+	hyper, info, err := cmdcore.FindVM(ctx, conf, args[0])
 	if err != nil {
 		return fmt.Errorf("inspect: %w", err)
 	}

--- a/cmd/vm/reseed_test.go
+++ b/cmd/vm/reseed_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestSignalReseed_SkipsWindows(t *testing.T) {
-	// VsockSocket is set: a regressed Windows guard would fall through to a dial instead of skipping.
 	vm := &types.VM{ID: "vm1", Config: types.VMConfig{Config: types.Config{Windows: true}}, VsockSocket: "/tmp/whatever.sock"}
 	if signalReseed(t.Context(), vm, true) {
 		t.Error("attempted reseed on a Windows guest, want skip")
@@ -50,7 +49,6 @@ func TestReseedVM_CtxCanceled(t *testing.T) {
 
 // TestReseedVM_AgentRejectionNotRetried pins the dial-vs-rejection distinction: once the agent answers, its reply is final and must not be billed the retry budget.
 func TestReseedVM_AgentRejectionNotRetried(t *testing.T) {
-	// A short dir: unix socket paths are capped at ~104 bytes, which t.TempDir() blows past.
 	dir, err := os.MkdirTemp("/tmp", "rsd")
 	if err != nil {
 		t.Fatalf("temp dir: %v", err)
@@ -74,9 +72,9 @@ func TestReseedVM_AgentRejectionNotRetried(t *testing.T) {
 			}
 			accepts.Add(1)
 			br := bufio.NewReader(conn)
-			_, _ = br.ReadString('\n')            // CONNECT <port>
-			_, _ = io.WriteString(conn, "OK 1\n") // hybrid-vsock handshake ack
-			_, _ = br.ReadString('\n')            // reseed opening frame
+			_, _ = br.ReadString('\n')
+			_, _ = io.WriteString(conn, "OK 1\n")
+			_, _ = br.ReadString('\n')
 			_ = agent.NewEncoder(conn).Encode(agent.Message{Type: agent.MsgError, Message: "version skew"})
 			_ = conn.Close()
 		}

--- a/cmd/vm/run.go
+++ b/cmd/vm/run.go
@@ -152,18 +152,13 @@ func (h Handler) Restore(cmd *cobra.Command, args []string) error {
 		return h.restoreFromDir(ctx, cmd, conf, vmRef, fromDir, logger)
 	}
 
-	hyper, err := cmdcore.FindHypervisor(ctx, conf, vmRef)
+	hyper, vm, err := cmdcore.FindVM(ctx, conf, vmRef)
 	if err != nil {
 		return fmt.Errorf("find VM %s: %w", vmRef, err)
 	}
 	snapBackend, err := cmdcore.InitSnapshot(ctx, conf)
 	if err != nil {
 		return err
-	}
-
-	vm, err := hyper.Inspect(ctx, vmRef)
-	if err != nil {
-		return fmt.Errorf("inspect VM: %w", err)
 	}
 	snapInfo, err := snapBackend.Inspect(ctx, snapRef)
 	if err != nil {
@@ -212,17 +207,13 @@ func (h Handler) restoreFromDir(ctx context.Context, cmd *cobra.Command, conf *c
 	if err != nil {
 		return fmt.Errorf("load envelope: %w", err)
 	}
-	hyper, err := cmdcore.FindHypervisor(ctx, conf, vmRef)
+	hyper, vm, err := cmdcore.FindVM(ctx, conf, vmRef)
 	if err != nil {
 		return fmt.Errorf("find VM %s: %w", vmRef, err)
 	}
 	dcr, ok := hyper.(hypervisor.Direct)
 	if !ok {
 		return fmt.Errorf("backend %s does not support direct restore", hyper.Type())
-	}
-	vm, err := hyper.Inspect(ctx, vmRef)
-	if err != nil {
-		return fmt.Errorf("inspect VM: %w", err)
 	}
 	if _, owned := vm.SnapshotIDs[cfg.ID]; !owned {
 		force, _ := cmd.Flags().GetBool("force")

--- a/cmd/vm/status.go
+++ b/cmd/vm/status.go
@@ -291,7 +291,9 @@ func matchesFilter(vm *types.VM, filters []string) bool {
 func snapshotAll(vms []*types.VM) []vmSnapshot {
 	result := make([]vmSnapshot, len(vms))
 	for i, vm := range vms {
-		result[i] = takeSnapshot(vm, cmdcore.ReconcileState(vm))
+		state := cmdcore.ReconcileState(vm)
+		vm.State = types.VMState(state)
+		result[i] = takeSnapshot(vm, state)
 	}
 	return result
 }
@@ -304,7 +306,7 @@ func printVMTable(w *tabwriter.Writer, vms []*types.VM, scopeDir string) {
 	fmt.Fprintln(w, "ID\tNAME\tSTATE\tCPU\tMEMORY\tSTORAGE\tTHROTTLED\tIP\tIMAGE\tCREATED") //nolint:errcheck
 	for _, vm := range vms {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\n", //nolint:errcheck
-			vm.ID, vm.Config.Name, cmdcore.ReconcileState(vm),
+			vm.ID, vm.Config.Name, vm.State,
 			vm.Config.CPU, cliutil.FormatSize(vm.Config.Memory),
 			cliutil.FormatSize(vm.Config.Storage),
 			vmThrottled(scopeDir, vm),

--- a/cmd/vm/status_test.go
+++ b/cmd/vm/status_test.go
@@ -158,7 +158,6 @@ func TestApplyFilters(t *testing.T) {
 	}
 }
 
-// captureStdout redirects os.Stdout to a pipe, runs fn, returns the bytes; panic-safe via deferred cleanup.
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 	r, w, err := os.Pipe()

--- a/console/relay.go
+++ b/console/relay.go
@@ -12,7 +12,7 @@ import (
 
 // Relay runs bidirectional I/O with escape-sequence detection. Caller must close rw to unblock the unfinished goroutine.
 func Relay(rw io.ReadWriter, escapeKeys []byte) error {
-	errCh := make(chan error, 2) //nolint:mnd
+	errCh := make(chan error, 2) //nolint:mnd // one slot per pump direction
 
 	go func() {
 		_, err := io.Copy(os.Stdout, rw)
@@ -67,9 +67,9 @@ func validateEscapeByte(b byte) (byte, error) {
 		return 0, fmt.Errorf("nul cannot be used as escape character")
 	case b == '\r' || b == '\n':
 		return 0, fmt.Errorf("cr/lf cannot be used as escape character")
-	case b == 0x7F: //nolint:mnd
+	case b == 0x7F: //nolint:mnd // DEL
 		return 0, fmt.Errorf("del (0x7f) cannot be used as escape character")
-	case b >= 0x80: //nolint:mnd
+	case b >= 0x80: //nolint:mnd // non-ASCII
 		return 0, fmt.Errorf("non-ASCII byte 0x%02X cannot be used as escape character", b)
 	}
 	return b, nil

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -27,8 +27,7 @@ const (
 	lockFileName = "daemon.lock"
 )
 
-// ErrAlreadyRunning reports another daemon instance holding the single-instance lock.
-var ErrAlreadyRunning = errors.New("another cocoon daemon is already running")
+var errAlreadyRunning = errors.New("another cocoon daemon is already running")
 
 // Supervisor is the backend surface supervision drives.
 type Supervisor = hypervisor.Supervisable
@@ -75,7 +74,7 @@ func New(conf Config, store meta.Store, backends []Supervisor) (*Daemon, error) 
 	}, nil
 }
 
-// Run supervises until ctx is canceled; it returns ErrAlreadyRunning when another instance holds the lock.
+// Run supervises until ctx is canceled; it fails when another instance holds the single-instance lock.
 func (d *Daemon) Run(ctx context.Context) error {
 	logger := log.WithFunc("daemon.Run")
 	unlock, lockErr := d.lockInstance(ctx)
@@ -154,7 +153,7 @@ func (d *Daemon) lockInstance(ctx context.Context) (func(), error) {
 		return nil, fmt.Errorf("acquire daemon lock: %w", err)
 	}
 	if !ok {
-		return nil, ErrAlreadyRunning
+		return nil, errAlreadyRunning
 	}
 	return func() { _ = l.Unlock(ctx) }, nil
 }
@@ -173,7 +172,7 @@ func (d *Daemon) settle(ctx context.Context) bool {
 
 // gcTick returns the periodic-GC channel and its stop; with GC off (the default) the nil channel keeps the select arm inert.
 func (d *Daemon) gcTick() (<-chan time.Time, func()) {
-	if d.conf.GCInterval <= 0 {
+	if d.conf.GCInterval <= 0 || d.conf.GC == nil {
 		return nil, func() {}
 	}
 	t := time.NewTicker(d.conf.GCInterval)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -27,7 +27,7 @@ const (
 	lockFileName = "daemon.lock"
 )
 
-var errAlreadyRunning = errors.New("another cocoon daemon is already running")
+var ErrAlreadyRunning = errors.New("another cocoon daemon is already running")
 
 // Supervisor is the backend surface supervision drives.
 type Supervisor = hypervisor.Supervisable
@@ -153,7 +153,7 @@ func (d *Daemon) lockInstance(ctx context.Context) (func(), error) {
 		return nil, fmt.Errorf("acquire daemon lock: %w", err)
 	}
 	if !ok {
-		return nil, errAlreadyRunning
+		return nil, ErrAlreadyRunning
 	}
 	return func() { _ = l.Unlock(ctx) }, nil
 }

--- a/daemon/watch.go
+++ b/daemon/watch.go
@@ -62,11 +62,11 @@ func (w *procWatcher) start(ctx context.Context) error {
 func (w *procWatcher) close() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	for key, entry := range w.byKey {
-		delete(w.byKey, key)
-		delete(w.byFD, entry.fd)
+	for _, entry := range w.byKey {
 		utils.CloseFD(entry.fd)
 	}
+	clear(w.byKey)
+	clear(w.byFD)
 	_ = w.poll.close()
 }
 

--- a/daemon/watch_linux_test.go
+++ b/daemon/watch_linux_test.go
@@ -51,7 +51,6 @@ func TestWatcherReplacesOnNewGeneration(t *testing.T) {
 		t.Fatalf("got watched pid %d, want the newer generation %d", got, second.PID)
 	}
 
-	// Only the adopted generation may report: the replaced one is no longer watched.
 	_ = cmd2.Process.Kill()
 	select {
 	case ev := <-w.exits:
@@ -89,7 +88,6 @@ func TestWatcherKeepsOtherBackendsOnDropAbsent(t *testing.T) {
 	}
 }
 
-// startVictim launches a process the test can kill, returning its generation.
 func startVictim(t *testing.T) (*exec.Cmd, utils.ProcRef) {
 	t.Helper()
 	cmd := exec.Command("sleep", "30")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,7 +15,7 @@ cocoon
 ├── vm
 │   ├── create [flags] IMAGE       Create a VM from an image
 │   ├── run [flags] IMAGE          Create and start a VM
-│   ├── clone [flags] SNAPSHOT     Clone a new VM from a snapshot
+│   ├── clone [flags] [SNAPSHOT]   Clone a new VM from a snapshot (or --from-dir)
 │   ├── start VM [VM...]           Start created/stopped VM(s)
 │   ├── stop VM [VM...]            Stop running VM(s)
 │   ├── list (alias: ls)           List VMs with status
@@ -26,7 +26,7 @@ cocoon
 │   ├── logs [-f] [--tail N] VM    Print the per-VM hypervisor log file
 │   ├── rm [flags] VM [VM...]      Delete VM(s) (--force kills running VMs immediately)
 │   ├── reconcile-stale-create VM  Reclaim an ownerless creating placeholder (JSON outcome)
-│   ├── restore [flags] VM SNAP   Restore a VM (running or stopped) to a snapshot
+│   ├── restore [flags] VM [SNAP] Restore a VM (running or stopped) to a snapshot (or --from-dir)
 │   ├── hibernate [flags] VM       Atomically snapshot a running VM and stop it
 │   ├── status [VM...]             Watch VM status in real time
 │   ├── fs

--- a/docs/gc.md
+++ b/docs/gc.md
@@ -6,8 +6,8 @@ Cross-module GC, snapshot LRU eviction, and scheduled cleanup.
 
 `cocoon gc` performs cross-module garbage collection:
 
-1. **Lock** all modules (images, VMs, network, snapshots) — if any module is busy, the entire GC cycle is skipped to maintain consistency
-2. **Snapshot** all module indexes under lock
+1. **Recover** every module's interrupted deletions first, so discovery sees no half-removed resources
+2. **Snapshot** each module's index (a loose read; every destructive decision is revalidated later under the module's own entity locks and tombstone leases)
 3. **Resolve** each module identifies unreferenced resources using the full snapshot set (e.g., image GC checks VM and snapshot records for blob references)
 4. **Collect** — delete identified targets
 
@@ -22,7 +22,7 @@ INFO gc.snapshot          collected id=XEOU... name=ubuntu-hot-testing:v1 bytes=
 INFO gc.snapshot          collected id=2GQVEA... name= bytes=0 last_accessed=never reason=orphan
 INFO gc.cloud-hypervisor  collected id=ABC123 runDir=/var/lib/cocoon/run/cloudhypervisor/ABC123 logDir=/var/log/cocoon/cloudhypervisor/ABC123 reason=orphan-runDir
 INFO gc.oci               collected blob=b40150c1c2717d... reason=unreferenced
-INFO gc.cni               collected id=JKLMN netns=cocoon-JKLMN nics=2/2 reason=orphan
+INFO gc.cni               collected id=JKLMN netns=cocoon-JKLMN reason=orphan
 INFO gc.bridge            collected id=MNOPQ iface=btMNOPQ-0 reason=orphan-tap
 INFO gc.Run               completed: cloud-hypervisor=1 cni=1 oci=4 snapshot=3 (failures: 0, duration: 230ms)
 ```

--- a/docs/images.md
+++ b/docs/images.md
@@ -11,8 +11,8 @@ cocoon image pull ghcr.io/cocoonstack/cocoon/ubuntu:24.04
 # Cloud image from an HTTP(S) URL (auto-converted to qcow2 v3)
 cocoon image pull https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img
 
-# --force bypasses the cache when a mutable tag/URL was replaced upstream
-cocoon image pull --force ghcr.io/cocoonstack/cocoon/ubuntu:24.04
+# --force re-downloads a URL whose content was replaced upstream (OCI tags are re-resolved on every pull)
+cocoon image pull --force https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img
 ```
 
 Blobs are content-addressed (SHA-256) and deduplicated; OCI layers are converted to EROFS, cloud images to qcow2 v3.

--- a/docs/vm.md
+++ b/docs/vm.md
@@ -167,4 +167,4 @@ cocoon vm status --event
 cocoon vm status --event -n 2 my-vm other-vm
 ```
 
-State changes are detected via **fsnotify** on the VM index file (sub-second latency), with a configurable poll interval as fallback. Event mode emits `ADDED`, `MODIFIED`, and `REMOVED` lines suitable for machine consumption.
+State changes are detected via **fsnotify** on the meta store (the sqlite database's directory, or the json index file; sub-second latency), with a configurable poll interval as fallback. Event mode emits `ADDED`, `MODIFIED`, and `DELETED` lines suitable for machine consumption.

--- a/extend/vfio/vfio.go
+++ b/extend/vfio/vfio.go
@@ -25,7 +25,7 @@ var (
 	validIDRe = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$`)
 )
 
-// Spec is one attach request. PCI may be a short BDF, full BDF, or a sysfs path; normalizePath canonicalizes it.
+// Spec is one attach request. PCI may be a short BDF, full BDF, or a sysfs path; NormalizePath canonicalizes it.
 type Spec struct {
 	PCI string
 	ID  string
@@ -39,7 +39,7 @@ func (s *Spec) NormalizedPath() (string, error) {
 	if s.ID != "" && (strings.HasPrefix(s.ID, "cocoon-") || !validIDRe.MatchString(s.ID)) {
 		return "", fmt.Errorf("id %q invalid: must match [A-Za-z0-9][A-Za-z0-9_.-]{0,63} and not start with cocoon-", s.ID)
 	}
-	return normalizePath(s.PCI)
+	return NormalizePath(s.PCI)
 }
 
 // Attached is the inspect-time view of one VFIO device from running VM state.
@@ -59,8 +59,8 @@ type Lister interface {
 	DeviceList(ctx context.Context, vmRef string) ([]Attached, error)
 }
 
-// normalizePath maps {short BDF, full BDF, sysfs path} → canonical /sys/bus/pci/devices/<bdf>; rejects paths outside that root.
-func normalizePath(input string) (string, error) {
+// NormalizePath maps {short BDF, full BDF, sysfs path} → canonical /sys/bus/pci/devices/<bdf>; rejects paths outside that root.
+func NormalizePath(input string) (string, error) {
 	in := strings.TrimSpace(input)
 	if in == "" {
 		return "", fmt.Errorf("empty pci path")

--- a/extend/vfio/vfio.go
+++ b/extend/vfio/vfio.go
@@ -25,7 +25,7 @@ var (
 	validIDRe = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$`)
 )
 
-// Spec is one attach request. PCI may be a short BDF, full BDF, or a sysfs path; NormalizePath canonicalizes it.
+// Spec is one attach request. PCI may be a short BDF, full BDF, or a sysfs path; normalizePath canonicalizes it.
 type Spec struct {
 	PCI string
 	ID  string
@@ -39,7 +39,7 @@ func (s *Spec) NormalizedPath() (string, error) {
 	if s.ID != "" && (strings.HasPrefix(s.ID, "cocoon-") || !validIDRe.MatchString(s.ID)) {
 		return "", fmt.Errorf("id %q invalid: must match [A-Za-z0-9][A-Za-z0-9_.-]{0,63} and not start with cocoon-", s.ID)
 	}
-	return NormalizePath(s.PCI)
+	return normalizePath(s.PCI)
 }
 
 // Attached is the inspect-time view of one VFIO device from running VM state.
@@ -59,8 +59,8 @@ type Lister interface {
 	DeviceList(ctx context.Context, vmRef string) ([]Attached, error)
 }
 
-// NormalizePath maps {short BDF, full BDF, sysfs path} → canonical /sys/bus/pci/devices/<bdf>; rejects paths outside that root.
-func NormalizePath(input string) (string, error) {
+// normalizePath maps {short BDF, full BDF, sysfs path} → canonical /sys/bus/pci/devices/<bdf>; rejects paths outside that root.
+func normalizePath(input string) (string, error) {
 	in := strings.TrimSpace(input)
 	if in == "" {
 		return "", fmt.Errorf("empty pci path")

--- a/extend/vfio/vfio_test.go
+++ b/extend/vfio/vfio_test.go
@@ -27,7 +27,7 @@ func TestNormalizePath(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NormalizePath(tt.in)
+			got, err := normalizePath(tt.in)
 			if tt.wantErr != "" {
 				if err == nil {
 					t.Fatalf("want error containing %q, got nil", tt.wantErr)

--- a/extend/vfio/vfio_test.go
+++ b/extend/vfio/vfio_test.go
@@ -27,7 +27,7 @@ func TestNormalizePath(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := normalizePath(tt.in)
+			got, err := NormalizePath(tt.in)
 			if tt.wantErr != "" {
 				if err == nil {
 					t.Fatalf("want error containing %q, got nil", tt.wantErr)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cocoonstack/cocoon
 go 1.27.0
 
 require (
-	github.com/cocoonstack/cocoon-agent v0.2.1
+	github.com/cocoonstack/cocoon-agent v0.2.2-0.20260902180804-c7c06196e44b
 	github.com/containernetworking/cni v1.3.0
 	github.com/containernetworking/plugins v1.9.1
 	github.com/creack/pty v1.1.24

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 h1:ASDL+UJcILM
 github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506/go.mod h1:Mw7HqKr2kdtu6aYGn3tPmAftiP3QPX63LdK/zcariIo=
 github.com/cockroachdb/redact v1.1.8 h1:8eVLLj6juKxiKrAEw2b8cJvNqWq++U8WOfQFuL7KTaA=
 github.com/cockroachdb/redact v1.1.8/go.mod h1:GceHHpJ0rMDpYARL5In88Alq/xMBUtVlz7Qxix6ZVkw=
-github.com/cocoonstack/cocoon-agent v0.2.1 h1:irVSWalK0XOwp5nRvnajGhaEX+TjCEkjcYb9NS9yFpY=
-github.com/cocoonstack/cocoon-agent v0.2.1/go.mod h1:O45KkTxSPOtjxT2E7AsuVJIhUMu99Fv6zuQx7OQmojU=
+github.com/cocoonstack/cocoon-agent v0.2.2-0.20260902180804-c7c06196e44b h1:AptJq+AO2OV/wrHMr+GqIwMiTbB2XKsSnXUDNtdsiZY=
+github.com/cocoonstack/cocoon-agent v0.2.2-0.20260902180804-c7c06196e44b/go.mod h1:O45KkTxSPOtjxT2E7AsuVJIhUMu99Fv6zuQx7OQmojU=
 github.com/containernetworking/cni v1.3.0 h1:v6EpN8RznAZj9765HhXQrtXgX+ECGebEYEmnuFjskwo=
 github.com/containernetworking/cni v1.3.0/go.mod h1:Bs8glZjjFfGPHMw6hQu82RUgEPNGEaBb9KS5KtNMnJ4=
 github.com/containernetworking/plugins v1.9.1 h1:8oU6WsIsU3bpnNZuvHp74a6cE1MJwbj2P7s4/yTUNlA=

--- a/hypervisor/choreo_trace_test.go
+++ b/hypervisor/choreo_trace_test.go
@@ -36,7 +36,6 @@ func TestLegacyChoreographyTrace(t *testing.T) {
 	}
 	ctx := t.Context()
 
-	// The injected deterministic clock (design §10) makes results and final bytes exact against the legacy-recorded golden.
 	clock := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 	origNow := timeNow
 	timeNow = func() time.Time { return clock }
@@ -103,7 +102,6 @@ func TestLegacyChoreographyTrace(t *testing.T) {
 	_, err = b.ResolveRef(ctx, "beta")
 	record("rollback-then-resolve", "", err)
 
-	// delete: the P1 phase protocol replaces legacy's inline record removal; the differential holds at values, errors and final state.
 	vm1, err := b.LoadRecord(ctx, "VM1")
 	if err != nil {
 		t.Fatalf("load VM1 pre-delete: %v", err)
@@ -112,7 +110,6 @@ func TestLegacyChoreographyTrace(t *testing.T) {
 	_, err = b.ResolveRef(ctx, "alpha")
 	record("delete-then-resolve", "", err)
 
-	// gc pass: the real orchestration on both sides (discovery, seamed-clock age cutoff, ops lock, under-lock revalidation); real dirs mirror tracegen and never appear in compared output.
 	cfgDelta := &types.VMConfig{Name: "delta", Config: types.Config{CPU: 1}}
 	record("reserve-vm4", "", b.ReserveVM(ctx, "VM4", cfgDelta, nil, t.TempDir(), t.TempDir()))
 	clock = clock.Add(25 * time.Hour)

--- a/hypervisor/cloudhypervisor/args.go
+++ b/hypervisor/cloudhypervisor/args.go
@@ -165,7 +165,6 @@ func networkConfigToNet(nc *types.NetworkConfig) chNet {
 	}
 }
 
-// cocoonNetID is the deterministic CH device id for a cocoon-managed NIC.
 func cocoonNetID(mac string) string {
 	return cocoonNetIDPrefix + strings.ReplaceAll(mac, ":", "")
 }

--- a/hypervisor/cloudhypervisor/clone_test.go
+++ b/hypervisor/cloudhypervisor/clone_test.go
@@ -153,7 +153,7 @@ func TestPatchCHConfig_DiskCountMismatch(t *testing.T) {
 	path := writeCHConfig(t, dir, baseCHConfig())
 
 	opts := basePatchOpts()
-	// 3 storage configs vs 2 disks in config.
+
 	opts.storageConfigs = append(opts.storageConfigs, &types.StorageConfig{Path: "/extra"})
 	err := patchCHConfig(path, opts)
 	if err == nil {
@@ -286,7 +286,6 @@ func TestRebuildBootConfig(t *testing.T) {
 }
 
 func TestRestorePatchStorageConfigs_DropsAppendedCidata(t *testing.T) {
-	// Snapshot lacked cidata; ensureCloneCidata appended one — drop only that, keep data disks.
 	configs := []*types.StorageConfig{
 		{Path: "/o", Role: types.StorageRoleLayer},
 		{Path: "/d1", Role: types.StorageRoleData},
@@ -326,7 +325,6 @@ func TestRestorePatchStorageConfigs_KeepsAllWhenSnapshotHadCidata(t *testing.T) 
 }
 
 func TestRestoreAndResumeCloneHotplugsCidataByRole(t *testing.T) {
-	// Short dir: t.TempDir embeds the test name and busts the unix sockaddr limit.
 	sockDir, err := os.MkdirTemp("", "ch")
 	if err != nil {
 		t.Fatal(err)
@@ -357,7 +355,6 @@ func TestRestoreAndResumeCloneHotplugsCidataByRole(t *testing.T) {
 	go srv.Serve(ln) //nolint:errcheck
 	t.Cleanup(func() { _ = srv.Close() })
 
-	// The clone's --data-disk lands after the appended cidata, so hot-plug must match by Role, not last element.
 	storageConfigs := []*types.StorageConfig{
 		{Path: "/store/cow.raw", Role: types.StorageRoleCOW, Serial: "cocoon-cow"},
 		{Path: "/run/cidata.img", RO: true, Role: types.StorageRoleCidata},
@@ -415,7 +412,6 @@ func readRawJSON(t *testing.T, path string) map[string]any {
 	return result
 }
 
-// baseCHConfig returns a minimal CH config.json with extra fields that CH adds internally.
 func baseCHConfig() map[string]any {
 	return map[string]any{
 		"payload": map[string]any{
@@ -504,7 +500,6 @@ func basePatchOpts() *patchOptions {
 	}
 }
 
-// tmpScopeConf redirects the cgroup parent to a temp dir so Arm writes plain files.
 type tmpScopeConf struct {
 	*Config
 	parent string

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -215,7 +215,7 @@ func (ch *CloudHypervisor) resolveExternalVolume(path string) (string, error) {
 
 // lockedDeviceOp serializes device-set mutations per VM and returns the record plus a vm.info snapshot taken under the lock, making precheck-then-call atomic against concurrent attach/detach/restore.
 func (ch *CloudHypervisor) lockedDeviceOp(ctx context.Context, vmRef string) (*http.Client, hypervisor.VMRecord, *chVMInfoResponse, func(), error) {
-	hc, vmID, _, err := ch.runningVMClientWithRecord(ctx, vmRef)
+	hc, vmID, err := ch.runningVMClient(ctx, vmRef)
 	if err != nil {
 		return nil, hypervisor.VMRecord{}, nil, nil, err
 	}
@@ -297,27 +297,27 @@ func (ch *CloudHypervisor) detachWith(ctx context.Context, vmRef string, findID 
 	return nil
 }
 
-// runningVMClientWithRecord asserts the CH process is alive and returns an http.Client on its API socket plus the resolved record.
-func (ch *CloudHypervisor) runningVMClientWithRecord(ctx context.Context, vmRef string) (*http.Client, string, hypervisor.VMRecord, error) {
+// runningVMClient asserts the CH process is alive and returns an http.Client on its API socket plus the VM id.
+func (ch *CloudHypervisor) runningVMClient(ctx context.Context, vmRef string) (*http.Client, string, error) {
 	vmID, rec, err := ch.ResolveAndLoad(ctx, vmRef)
 	if err != nil {
-		return nil, "", hypervisor.VMRecord{}, err
+		return nil, "", err
 	}
 	if rec.State != types.VMStateRunning {
-		return nil, "", hypervisor.VMRecord{}, fmt.Errorf("vm %s is %s: %w", vmID, rec.State, hypervisor.ErrNotRunning)
+		return nil, "", fmt.Errorf("vm %s is %s: %w", vmID, rec.State, hypervisor.ErrNotRunning)
 	}
 	sockPath := hypervisor.SocketPath(rec.RunDir)
 	pid, pidErr := utils.ReadPIDFile(ch.PIDFilePath(rec.RunDir))
 	if pidErr != nil {
-		return nil, "", hypervisor.VMRecord{}, fmt.Errorf("vm %s read pidfile: %w: %w", vmID, pidErr, hypervisor.ErrNotRunning)
+		return nil, "", fmt.Errorf("vm %s read pidfile: %w: %w", vmID, pidErr, hypervisor.ErrNotRunning)
 	}
 	if !utils.VerifyProcessCmdline(pid, ch.conf.BinaryName(), sockPath) {
-		return nil, "", hypervisor.VMRecord{}, fmt.Errorf("vm %s pid %d not %s: %w", vmID, pid, ch.conf.BinaryName(), hypervisor.ErrNotRunning)
+		return nil, "", fmt.Errorf("vm %s pid %d not %s: %w", vmID, pid, ch.conf.BinaryName(), hypervisor.ErrNotRunning)
 	}
-	return utils.NewSocketHTTPClient(sockPath), vmID, rec, nil
+	return utils.NewSocketHTTPClient(sockPath), vmID, nil
 }
 
-// convergeOrphanedPause resumes a VM left paused by a dead capture and returns a refreshed vm.info; the pause is provably ownerless because callers hold the ops lock every capture window holds and runningVMClientWithRecord's Running gate excludes restore/clone windows.
+// convergeOrphanedPause resumes a VM left paused by a dead capture and returns a refreshed vm.info; the pause is provably ownerless because callers hold the ops lock every capture window holds and runningVMClient's Running gate excludes restore/clone windows.
 func convergeOrphanedPause(ctx context.Context, hc *http.Client, vmID string, info *chVMInfoResponse) (*chVMInfoResponse, error) {
 	if info.State != chStatePaused {
 		return info, nil
@@ -332,7 +332,7 @@ func convergeOrphanedPause(ctx context.Context, hc *http.Client, vmID string, in
 
 // listWith returns nil (not error) for stopped VMs so inspect can omit the field.
 func listWith[A any](ctx context.Context, ch *CloudHypervisor, vmRef string, extract func(*chVMInfoResponse) []A) ([]A, error) {
-	hc, _, _, err := ch.runningVMClientWithRecord(ctx, vmRef)
+	hc, _, err := ch.runningVMClient(ctx, vmRef)
 	if err != nil {
 		if errors.Is(err, hypervisor.ErrNotRunning) {
 			return nil, nil

--- a/hypervisor/cloudhypervisor/extend_test.go
+++ b/hypervisor/cloudhypervisor/extend_test.go
@@ -34,7 +34,6 @@ func TestResolveExternalVolume(t *testing.T) {
 
 	ch := &CloudHypervisor{conf: NewConfig(&config.Config{RootDir: rootDir, RunDir: runDir, LogDir: logDir})}
 
-	// t.TempDir may itself sit behind symlinks (macOS /var); expected values resolve too.
 	wantOK, err := filepath.EvalSymlinks(okVol)
 	if err != nil {
 		t.Fatalf("eval: %v", err)

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -24,7 +24,7 @@ func (ch *CloudHypervisor) NetResize(ctx context.Context, vmRef string, spec net
 	if err := spec.Normalize(); err != nil {
 		return netresize.Result{}, err
 	}
-	hc, vmID, rec, err := ch.runningVMClientWithRecord(ctx, vmRef)
+	hc, vmID, err := ch.runningVMClient(ctx, vmRef)
 	if err != nil {
 		return netresize.Result{}, err
 	}
@@ -34,7 +34,8 @@ func (ch *CloudHypervisor) NetResize(ctx context.Context, vmRef string, spec net
 	}
 	defer unlock()
 	// Entrypoint discipline (design §5): a resize must not plumb NICs onto a VM whose delete was interrupted. Reload under the lock: a resize that won the lock first may have changed the NIC set after this one loaded.
-	if rec, err = ch.EntryGuardLoad(ctx, vmID); err != nil {
+	rec, err := ch.EntryGuardLoad(ctx, vmID)
+	if err != nil {
 		return netresize.Result{}, err
 	}
 	info, err := getVMInfo(ctx, hc)

--- a/hypervisor/cloudhypervisor/netresize_test.go
+++ b/hypervisor/cloudhypervisor/netresize_test.go
@@ -34,7 +34,7 @@ func TestReconcileOrphanNICs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("vm.info: %v", err)
 	}
-	recorded := []*types.NetworkConfig{{MAC: "AA:BB:CC:DD:EE:01"}} // case-insensitive match
+	recorded := []*types.NetworkConfig{{MAC: "AA:BB:CC:DD:EE:01"}}
 	if err := reconcileOrphanNICs(t.Context(), hc, info, "vm1", recorded, plumbing); err != nil {
 		t.Fatalf("reconcileOrphanNICs: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestNetResizeRemoveResumesWithoutLiveDevice(t *testing.T) {
 	ctx := t.Context()
 	nc := &types.NetworkConfig{MAC: "aa:bb:cc:dd:ee:07", TAP: "tap-vm7-0"}
 	seedNetVM(t, ch, "vm7", nc)
-	// vm.info reports no live nets, so macToID can't resolve nc's MAC.
+
 	hc, _ := newCHStubClient(t, nil)
 	plumbing := &stubPlumbing{}
 
@@ -179,7 +179,7 @@ func TestConvergeOrphanedPause(t *testing.T) {
 	if resumes != 1 {
 		t.Fatalf("resumes = %d, want the orphaned pause resumed once", resumes)
 	}
-	// The returned info must be re-read: callers classify devices off it.
+
 	if fresh.State != "Running" {
 		t.Errorf("returned state = %q, want the refreshed Running", fresh.State)
 	}

--- a/hypervisor/cloudhypervisor/utils_test.go
+++ b/hypervisor/cloudhypervisor/utils_test.go
@@ -70,7 +70,7 @@ func TestSaveConsolePTYSkipsUEFI(t *testing.T) {
 
 func serveVMInfo(t *testing.T, ptyPath string) string {
 	t.Helper()
-	// os.MkdirTemp, not t.TempDir: unix socket paths cap at ~104 bytes.
+
 	sockDir, err := os.MkdirTemp("", "ch")
 	if err != nil {
 		t.Fatal(err)

--- a/hypervisor/disks.go
+++ b/hypervisor/disks.go
@@ -122,7 +122,7 @@ func PrepareOCICOW(ctx context.Context, cowPath string, storage int64, storageCo
 }
 
 func copyPairs(ctx context.Context, pairs [][2]string, sync utils.SyncMode) error {
-	_, err := utils.Map(ctx, pairs, func(_ context.Context, _ int, p [2]string) (struct{}, error) {
+	_, err := utils.Map(ctx, pairs, func(ctx context.Context, _ int, p [2]string) (struct{}, error) {
 		if err := utils.ReflinkCopy(ctx, p[0], p[1], sync); err != nil {
 			return struct{}{}, fmt.Errorf("copy %s: %w", filepath.Base(p[1]), err)
 		}

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -72,10 +72,6 @@ func (fc *Firecracker) cloneAfterExtract(ctx context.Context, vmID string, vmCfg
 	}
 
 	cowPath := fc.conf.COWRawPath(vmID)
-	snapshotCOW := filepath.Join(runDir, hypervisor.COWRawFileName)
-	if renameErr := os.Rename(snapshotCOW, cowPath); renameErr != nil {
-		return nil, fmt.Errorf("move COW to canonical path: %w", renameErr)
-	}
 
 	storageConfigs, err := rebuildCloneStorage(meta, cowPath)
 	if err != nil {

--- a/hypervisor/gc_test.go
+++ b/hypervisor/gc_test.go
@@ -18,7 +18,7 @@ func TestGCCollectKeepsLockedVM(t *testing.T) {
 	const id = "vm-gc-lock"
 	runDir, logDir := t.TempDir(), t.TempDir()
 	seedVMRecord(t, b, id, 1, 512, 1024, false)
-	// A fresh creating record: the free ops lock alone is the reclaim proof, no age gate.
+
 	if err := b.dbUpdate(ctx, func(idx *VMIndex) error {
 		idx.VMs[id].State = types.VMStateCreating
 		idx.VMs[id].RunDir = runDir
@@ -93,7 +93,6 @@ func TestSweepStaleCaptureDirsCoversPersistedRunDir(t *testing.T) {
 		t.Fatalf("age staging: %v", err)
 	}
 
-	// A --run-dir migration leaves crash leftovers in roots the config no longer names; the persisted record dir must still be swept.
 	snap := VMGCSnapshot{recRunDirs: []string{oldRunDir}}
 	for _, err := range b.sweepStaleCaptureDirs(t.Context(), snap.sweepDirs(b.Conf.RunDir())) {
 		t.Fatalf("sweep: %v", err)

--- a/hypervisor/hibernate_test.go
+++ b/hypervisor/hibernate_test.go
@@ -130,7 +130,6 @@ func newHibernateTestVM(t *testing.T) (*Backend, string) {
 		t.Fatalf("seed state: %v", err)
 	}
 
-	// argv[0] and the socket-path argument satisfy WithRunningVM's cmdline check.
 	sock := SocketPath(runDir)
 	if err := os.WriteFile(sock, nil, 0o600); err != nil {
 		t.Fatalf("touch sock: %v", err)
@@ -139,7 +138,7 @@ func newHibernateTestVM(t *testing.T) (*Backend, string) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start stub vmm: %v", err)
 	}
-	// Background reaper: a test-killed stub must not linger as a zombie, or TerminateProcess's IsProcessAlive polling never sees it exit.
+
 	waitDone := make(chan struct{})
 	go func() {
 		_ = cmd.Wait()
@@ -149,7 +148,7 @@ func newHibernateTestVM(t *testing.T) (*Backend, string) {
 		_ = cmd.Process.Kill()
 		<-waitDone
 	})
-	// cmd.Start returns before bash execs into tail; wait until the cmdline check would pass.
+
 	deadline := time.Now().Add(2 * time.Second)
 	for !utils.VerifyProcessCmdline(cmd.Process.Pid, b.Conf.BinaryName(), sock) {
 		if time.Now().After(deadline) {

--- a/hypervisor/inspect.go
+++ b/hypervisor/inspect.go
@@ -28,7 +28,7 @@ func (b *Backend) Inspect(ctx context.Context, ref string) (*types.VM, error) {
 	})
 }
 
-// List snapshots all records inside the transaction then runs ToVM (which does per-running-VM file IO) outside it and in parallel, so concurrent writers don't queue behind status polls and poll latency stays bounded by pool size, not fleet size.
+// List reads every record in one transaction and runs ToVM's per-VM file IO outside it, in parallel.
 func (b *Backend) List(ctx context.Context) ([]*types.VM, error) {
 	var recs []*VMRecord
 	if err := b.view(ctx, func(t *vmTx) error {

--- a/hypervisor/meta_test.go
+++ b/hypervisor/meta_test.go
@@ -48,7 +48,6 @@ func TestLegacyDifferentialTrace(t *testing.T) {
 	t.Cleanup(func() { _ = store.Close() })
 	b := &Backend{Typ: "test", NS: "vms_test", Meta: store}
 
-	// Fidelity: a no-op transaction must reproduce the legacy bytes exactly.
 	if err := b.update(ctx, func(*vmTx) error { return nil }); err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +59,6 @@ func TestLegacyDifferentialTrace(t *testing.T) {
 		t.Fatalf("round-trip not byte-identical to legacy baseline:\n got: %s\nwant: %s", got, baseline)
 	}
 
-	// Replay the exact op sequence fixturegen ran through the legacy store.
 	t2 := time.Date(2026, 7, 3, 12, 45, 0, 0, time.UTC)
 	if err := b.update(ctx, func(t *vmTx) error {
 		g, err := t.Get("VMCCCCCCCCCCCCCCCCCCCCCCCC")

--- a/hypervisor/restore_test.go
+++ b/hypervisor/restore_test.go
@@ -164,7 +164,6 @@ func TestRestorePartialMergeQuarantinesEvenStoppedOrigin(t *testing.T) {
 		t.Fatalf("seed state: %v", err)
 	}
 
-	// Staged file "b" cannot rename over the run dir's directory "b", so the merge fails halfway through.
 	if err := os.MkdirAll(filepath.Join(runDir, "b"), 0o750); err != nil {
 		t.Fatalf("setup: %v", err)
 	}

--- a/hypervisor/snapshot_test.go
+++ b/hypervisor/snapshot_test.go
@@ -157,14 +157,13 @@ func TestReverseLayers_NoLayers(t *testing.T) {
 }
 
 func TestValidateMetaPathsResidentExemption(t *testing.T) {
-	// Resident disks travel inside the snapshot, so path validation treats a resident entry as provenance only; clone additionally requires source paths under the managed run dir at bind time.
 	meta := &SnapshotMeta{StorageConfigs: []*types.StorageConfig{
 		{Path: "/old-run/firecracker/vm1/cow.raw", RO: false, Role: types.StorageRoleCOW, Serial: "cow"},
 	}}
 	if err := ValidateMetaPaths(meta, "/var/lib/cocoon", "/new-run"); err != nil {
 		t.Fatalf("resident path must be provenance-only: %v", err)
 	}
-	// Degenerate resident paths must not degrade integrity into statting a directory.
+
 	for _, bad := range []string{"", ".", "..", "/", "/old-run/.."} {
 		meta.StorageConfigs[0].Path = bad
 		if err := ValidateMetaPaths(meta, "/var/lib/cocoon", "/new-run"); err == nil {
@@ -172,7 +171,7 @@ func TestValidateMetaPathsResidentExemption(t *testing.T) {
 		}
 	}
 	meta.StorageConfigs[0].Path = "/old-run/firecracker/vm1/cow.raw"
-	// Dereferenced paths stay strict.
+
 	meta.StorageConfigs = append(meta.StorageConfigs, &types.StorageConfig{Path: "/elsewhere/layer.erofs", RO: true, Role: types.StorageRoleLayer, Serial: "l0"})
 	if err := ValidateMetaPaths(meta, "/var/lib/cocoon", "/new-run"); err == nil {
 		t.Fatal("a layer outside the blob store must stay untrusted")

--- a/hypervisor/state_test.go
+++ b/hypervisor/state_test.go
@@ -102,7 +102,6 @@ func TestUpdateStatesRunningIsRejected(t *testing.T) {
 }
 
 func TestPrepareStartClosesIntervalAfterMarkError(t *testing.T) {
-	// Running→Error must leave the interval open (UpdateStates(Error) doesn't write StoppedAt). The next PrepareStart confirms the process is dead and closes the interval.
 	b, rec := newMeteringTestBackend(t)
 	ctx := t.Context()
 	seedRunningVM(t, b, "vm1", 2, 2<<30, 20<<30)
@@ -138,7 +137,6 @@ func TestPrepareStartClosesIntervalAfterMarkError(t *testing.T) {
 }
 
 func TestStopAfterMarkErrorEmitsComputeStop(t *testing.T) {
-	// Running→Error→Stopped: MarkError leaves the interval open; the recovery stop confirms the process is dead and must close it.
 	b, rec := newMeteringTestBackend(t)
 	ctx := t.Context()
 	seedRunningVM(t, b, "vm1", 2, 2<<30, 20<<30)
@@ -159,7 +157,6 @@ func TestStopAfterMarkErrorEmitsComputeStop(t *testing.T) {
 }
 
 func TestDeleteForceClosesIntervalAfterMarkError(t *testing.T) {
-	// rm --force on an Error VM with a still-open interval must emit compute.stop, not just storage.stop.
 	b, rec := newMeteringTestBackend(t)
 	ctx := t.Context()
 	seedRunningVM(t, b, "vm1", 2, 2<<30, 20<<30)
@@ -268,7 +265,7 @@ func TestDirectRestoreSequenceEmitsComputeStopThenTransition(t *testing.T) {
 	}
 
 	entries := rec.Entries()
-	// compute.stop on kill; storage.stop + storage.start + compute.start on success.
+
 	if len(entries) != 4 {
 		t.Fatalf("got %d entries, want 4", len(entries))
 	}
@@ -287,7 +284,7 @@ func TestDirectRestoreSequenceEmitsComputeStopThenTransition(t *testing.T) {
 			t.Errorf("entries[%d].SourceSnapshotID = %q, want snap-src", i, entries[i].SourceSnapshotID)
 		}
 	}
-	// compute.stop and storage.stop carry the old shape; the open pair carries the new shape.
+
 	for i := range 2 {
 		if entries[i].Shape.CPU != 2 {
 			t.Errorf("close entry %d cpu=%d, want 2 (old shape)", i, entries[i].Shape.CPU)
@@ -301,7 +298,6 @@ func TestDirectRestoreSequenceEmitsComputeStopThenTransition(t *testing.T) {
 }
 
 func TestDirectRestoreSequenceEmitsOnlyComputeStopOnPopulateFailure(t *testing.T) {
-	// Storage stays open when restore fails after kill: the on-disk files are still the old shape and vm rm closes it later.
 	b, rec := newMeteringTestBackend(t)
 	ctx := t.Context()
 	seedRunningVM(t, b, "vm1", 2, 2<<30, 20<<30)
@@ -331,14 +327,12 @@ func TestDirectRestoreSequenceEmitsOnlyComputeStopOnPopulateFailure(t *testing.T
 }
 
 func TestStartAllOnlyEmitsForActuallyLaunched(t *testing.T) {
-	// BatchMarkStarted skipping every r.State==Running silently drops vm-stale (DB Running, process dead, relaunched).
 	b, rec := newMeteringTestBackend(t)
 	ctx := t.Context()
 	seedVMRecord(t, b, "vm-stopped", 1, 1<<30, 10<<30, false)
 	seedRunningVM(t, b, "vm-running", 1, 1<<30, 10<<30)
 	seedRunningVM(t, b, "vm-stale", 2, 2<<30, 20<<30)
 
-	// Mimics StartSequence's per-VM contract: only an actual launch flips state.
 	startOne := func(ctx context.Context, id string) error {
 		switch id {
 		case "vm-stopped", "vm-stale":
@@ -386,7 +380,7 @@ func TestStartAllOnlyEmitsForActuallyLaunched(t *testing.T) {
 func TestFinalizeCreateEmitsStorageStart(t *testing.T) {
 	b, rec := newMeteringTestBackend(t)
 	ctx := t.Context()
-	// FinalizeCreate requires an existing placeholder.
+
 	seedVMRecord(t, b, "vm1", 2, 2<<30, 20<<30, false)
 
 	info := &types.VM{
@@ -460,7 +454,6 @@ func TestReconcileToRunningFromError(t *testing.T) {
 }
 
 func TestReconcileToRunningOrphanLaunchEmitsStart(t *testing.T) {
-	// BatchMarkStarted's DB write failed after a successful launch: process is alive but record is still Created (StartedAt=nil, no ledger compute.start). reconcile must emit a fresh start so a later stop has a matching open interval.
 	b, rec := newMeteringTestBackend(t)
 	ctx := t.Context()
 	seedVMRecord(t, b, "vm1", 2, 2<<30, 20<<30, false)
@@ -484,7 +477,6 @@ func TestReconcileToRunningOrphanLaunchEmitsStart(t *testing.T) {
 }
 
 func TestReconcileToRunningOrphanLaunchAfterFirstBoot(t *testing.T) {
-	// Same orphan, but the VM was booted before: reconcile uses reason=restart.
 	b, rec := newMeteringTestBackend(t)
 	ctx := t.Context()
 	seedVMRecord(t, b, "vm1", 1, 1<<30, 10<<30, true)
@@ -540,7 +532,6 @@ func TestPrepareStartRefusesQuarantined(t *testing.T) {
 		t.Fatal("PrepareStart must refuse a quarantined VM")
 	}
 
-	// Stop's state flip must not lift the quarantine.
 	if err := b.UpdateStates(ctx, []string{"vm1"}, types.VMStateStopped); err != nil {
 		t.Fatalf("UpdateStates: %v", err)
 	}
@@ -692,7 +683,7 @@ func seedVMRecord(t *testing.T, b *Backend, id string, cpu int, mem, storage int
 				Config:      types.VMConfig{Config: types.Config{CPU: cpu, Memory: mem, Storage: storage}},
 				FirstBooted: firstBooted,
 			},
-			// Real dirs by default: sequences write markers into RunDir, and an empty path would land them in the package dir.
+
 			RunDir: t.TempDir(),
 			LogDir: t.TempDir(),
 		}

--- a/hypervisor/stop.go
+++ b/hypervisor/stop.go
@@ -86,7 +86,7 @@ func (b *Backend) DeleteAll(ctx context.Context, refs []string, force bool, stop
 	if err != nil {
 		return nil, err
 	}
-	// One /proc scan up-front; per-VM orphan check filters this cache instead of re-walking /proc N times.
+	// one /proc scan serves every VM's orphan check
 	procScan, scanErr := utils.ScanProcsByBinary(b.Conf.BinaryName())
 	if scanErr != nil {
 		return nil, fmt.Errorf("refuse delete: /proc scan errored: %w (resolve the host issue and retry)", scanErr)

--- a/hypervisor/stop_test.go
+++ b/hypervisor/stop_test.go
@@ -125,7 +125,6 @@ func TestStopStaleStoppedRecordWithLiveVMMStillTransitions(t *testing.T) {
 	}
 }
 
-// TestDeleteAllForceStopsUnderLock drives the force path against a live stub VMM: the delete body holds the ops lock while stopLocked runs, so a re-locking stop variant deadlocks here.
 func TestDeleteAllForceStopsUnderLock(t *testing.T) {
 	b, id := newHibernateTestVM(t)
 	ctx := t.Context()
@@ -215,7 +214,6 @@ func TestDeleteMigratedVMClearsCleanupIntent(t *testing.T) {
 	}
 }
 
-// A forced delete's stop already closes the compute interval; emitting again from the pre-stop record would bill two stops against one start.
 func TestDeleteForceEmitsOneComputeStop(t *testing.T) {
 	b, id := newHibernateTestVM(t)
 	ctx := t.Context()
@@ -246,7 +244,6 @@ func TestDeleteForceEmitsOneComputeStop(t *testing.T) {
 	}
 }
 
-// shortTempDir is a /tmp-based TempDir: unix socket paths under t.TempDir() can exceed the ~104-byte sockaddr cap (EINVAL on dial).
 func shortTempDir(t *testing.T) string {
 	t.Helper()
 	dir, err := os.MkdirTemp("/tmp", "cocoon-test-")

--- a/hypervisor/supervisor_test.go
+++ b/hypervisor/supervisor_test.go
@@ -146,7 +146,6 @@ func TestQuiesceIfPendingFencedByGeneration(t *testing.T) {
 	ctx := t.Context()
 	seedPlumbedVM(t, b, "vm1")
 	b.SetNetwork(stubNetwork{quiesce: func(context.Context, *types.VM) error {
-		// A concurrent stop transitions the record while the quiesce is in flight.
 		return b.UpdateStates(ctx, []string{"vm1"}, types.VMStateStopped)
 	}})
 	if err := b.dbUpdate(ctx, func(idx *VMIndex) error {

--- a/hypervisor/teardown_test.go
+++ b/hypervisor/teardown_test.go
@@ -56,7 +56,7 @@ func TestDeleteProtocolTeardownFailureKeepsTombstoneThenConverges(t *testing.T) 
 	if err := b.deleteVMProtocol(ctx, "vmproto2", rec); !errors.Is(err, boom) {
 		t.Fatalf("want teardown failure surfaced, got %v", err)
 	}
-	// Record stays live over a deleting tombstone; the retry rolls forward.
+
 	if _, err := b.LoadRecord(ctx, "vmproto2"); err != nil {
 		t.Fatalf("record must stay live through deleting: %v", err)
 	}
@@ -75,7 +75,6 @@ func TestRecoverLeasedRollsBack(t *testing.T) {
 	ctx := t.Context()
 	rec := seedProtoVM(t, b, "vmproto3")
 
-	// Simulate a crash right after the lease transaction: insert the lease only.
 	cleanup, err := tombstone.MarshalCleanup(vmCleanup{Name: rec.Config.Name, RunDir: rec.RunDir, LogDir: rec.LogDir})
 	if err != nil {
 		t.Fatal(err)
@@ -123,12 +122,12 @@ func TestTombstoneFencingABA(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	// Worker B recovers under a NEW lease and finalizes.
+
 	done, err := b.recoverVMTombstone(ctx, "vmproto4")
 	if err != nil || !done {
 		t.Fatalf("recover: done=%v err=%v", done, err)
 	}
-	// Replaying A's fenced finalize affects nothing.
+
 	err = b.update(ctx, func(tx *vmTx) error {
 		return ts.Finalize(ctx, tx.w, "vmproto4", leaseA)
 	})
@@ -147,7 +146,6 @@ func TestEntryGuardDisciplines(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// leased: the guard rolls it back in place and the operation proceeds.
 	if err := b.update(ctx, func(tx *vmTx) error {
 		_, err := ts.Lease(ctx, tx.w, "vmproto5", tombstone.Payload{Kind: tombstone.KindRecord, Mode: tombstone.ModeAggregate, Cleanup: cleanup})
 		return err

--- a/hypervisor/utils.go
+++ b/hypervisor/utils.go
@@ -1,6 +1,7 @@
 package hypervisor
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -106,15 +107,11 @@ func (b *Backend) LogFilePath(logDir string) string {
 
 // LogPath resolves ref → log path via the persisted LogDir (survives --log-dir change); falls back to current Conf for legacy records.
 func (b *Backend) LogPath(ctx context.Context, ref string) (string, error) {
-	id, err := b.ResolveRef(ctx, ref)
+	id, rec, err := b.ResolveAndLoad(ctx, ref)
 	if err != nil {
 		return "", err
 	}
-	logDir := b.Conf.VMLogDir(id)
-	if rec, err := b.LoadRecord(ctx, id); err == nil && rec.LogDir != "" {
-		logDir = rec.LogDir
-	}
-	return b.LogFilePath(logDir), nil
+	return b.LogFilePath(cmp.Or(rec.LogDir, b.Conf.VMLogDir(id))), nil
 }
 
 // ForEachVM runs fn over ids in parallel up to EffectivePoolSize, logging per-id failures.
@@ -365,7 +362,7 @@ func VerifyBaseFiles(storageConfigs []*types.StorageConfig, boot *types.BootConf
 	return nil
 }
 
-// CloneSnapshotFiles copies snapshot files using per-file strategies to minimize I/O; COW-class copies (the bulk of the bytes) fan out concurrently, links and small meta stay serial.
+// CloneSnapshotFiles copies snapshot files by kind: COW-class copies fan out concurrently, links and small meta stay serial.
 func CloneSnapshotFiles(ctx context.Context, dstDir, srcDir string, classify func(name string) SnapshotFileKind) error {
 	entries, err := os.ReadDir(srcDir)
 	if err != nil {

--- a/hypervisor/utils_test.go
+++ b/hypervisor/utils_test.go
@@ -64,7 +64,6 @@ func TestValidateSnapshotIntegrity(t *testing.T) {
 	})
 
 	t.Run("invalid sidecar rejected by ValidateStorageConfigs", func(t *testing.T) {
-		// Layer with RO=false fails the structural check before file stat.
 		bad := []*types.StorageConfig{
 			{Path: "/x", RO: false, Role: types.StorageRoleLayer, Serial: "x"},
 		}
@@ -75,7 +74,6 @@ func TestValidateSnapshotIntegrity(t *testing.T) {
 	})
 
 	t.Run("layers skipped (not in srcDir)", func(t *testing.T) {
-		// Only a Layer entry; its blob path is not under dir, but Layer is skipped.
 		layerOnly := []*types.StorageConfig{
 			{Path: "/some/other/blob.erofs", RO: true, Role: types.StorageRoleLayer, Serial: "l"},
 		}

--- a/images/cloudimg/cloudimg.go
+++ b/images/cloudimg/cloudimg.go
@@ -76,7 +76,6 @@ func (c *CloudImg) ImportFromReader(ctx context.Context, name string, tracker pr
 	return importQcow2Reader(ctx, c.conf, c.store, name, tracker, r)
 }
 
-// Config resolves cloud images to qcow2 storage plus firmware boot config.
 func (c *CloudImg) Config(ctx context.Context, vms []*types.VMConfig) (result [][]*types.StorageConfig, boot []*types.BootConfig, err error) {
 	err = c.store.View(ctx, func(idx *imageIndex) error {
 		result = make([][]*types.StorageConfig, len(vms))

--- a/images/cloudimg/pull.go
+++ b/images/cloudimg/pull.go
@@ -70,6 +70,7 @@ func (cw countingWriter) Write(p []byte) (int, error) {
 type rangeProbe struct {
 	finalURL string
 	size     int64
+	head     []byte
 }
 
 // pull commits url as a blob; the URL→blob mapping is idempotent (no-op when the blob already exists).
@@ -138,6 +139,9 @@ func downloadToFile(ctx context.Context, url string, dst *os.File, tracker progr
 	if probe.size > maxDownloadBytes {
 		return "", fmt.Errorf("download %s: exceeded max size (%d bytes)", url, maxDownloadBytes)
 	}
+	if err := sniffHead(probe.head); err != nil {
+		return "", fmt.Errorf("download %s: %w", url, err)
+	}
 
 	logger.Debugf(ctx, "downloading %s in %d parallel range(s)", url, pullConns)
 	if err := downloadRangesParallel(ctx, client, probe.finalURL, dst, probe.size, pullConns, tracker); err != nil {
@@ -189,13 +193,13 @@ func downloadSerial(ctx context.Context, client *http.Client, url string, dst *o
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
-// probeRangeSupport GETs Range: bytes=0-0 (nil = no usable Range support); the returned URL is post-redirect so range requests skip the redirect chain.
+// probeRangeSupport GETs the first sniffHead bytes (nil = no usable Range support); the returned URL is post-redirect so range requests skip the redirect chain.
 func probeRangeSupport(ctx context.Context, client *http.Client, url string) (*rangeProbe, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create range probe request: %w", err)
 	}
-	req.Header.Set("Range", "bytes=0-0")
+	req.Header.Set("Range", "bytes=0-7")
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -210,7 +214,11 @@ func probeRangeSupport(ctx context.Context, client *http.Client, url string) (*r
 	if !ok {
 		return nil, nil
 	}
-	return &rangeProbe{finalURL: resp.Request.URL.String(), size: size}, nil
+	head, err := io.ReadAll(io.LimitReader(resp.Body, 8)) //nolint:mnd
+	if err != nil {
+		return nil, fmt.Errorf("read range probe body for %s: %w", url, err)
+	}
+	return &rangeProbe{finalURL: resp.Request.URL.String(), size: size, head: head}, nil
 }
 
 // downloadRangesParallel splits [0,size) into pullConns contiguous ranges downloaded concurrently into disjoint offsets of dst.

--- a/images/cloudimg/pull_test.go
+++ b/images/cloudimg/pull_test.go
@@ -36,7 +36,6 @@ func TestDownloadToFileParallelRange(t *testing.T) {
 func TestDownloadToFileFallsBackWhenRangeUnsupported(t *testing.T) {
 	data := testPayload(64 * 1024)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		// Ignores any Range header and always serves the full body — not Range-capable.
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(data)
 	}))
@@ -99,7 +98,7 @@ func TestDownloadToFileEmitsFinalProgressEvent(t *testing.T) {
 }
 
 func TestDownloadToFileUnevenLastRange(t *testing.T) {
-	data := testPayload(257*1024 + 7) // not divisible by 4: exercises the short final range
+	data := testPayload(257*1024 + 7)
 	server := httptest.NewServer(rangeHandler(data, nil))
 	defer server.Close()
 
@@ -135,7 +134,7 @@ func TestDownloadToFileFollowsRedirectForRanges(t *testing.T) {
 		t.Errorf("digest = %s, want %s", digest, want)
 	}
 	assertFileContent(t, dst, data)
-	// Only the probe may hit the front server; range requests go straight to the resolved URL.
+
 	if n := frontRequests.Load(); n != 1 {
 		t.Errorf("front server saw %d requests, want 1 (probe only)", n)
 	}
@@ -153,10 +152,10 @@ func TestDownloadToFileShortRangeBodyFails(t *testing.T) {
 		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(data)))
 		w.WriteHeader(http.StatusPartialContent)
 		if start == 0 || end-start < 2 {
-			_, _ = w.Write(data[start : end+1]) // probe and tiny ranges served fully
+			_, _ = w.Write(data[start : end+1])
 			return
 		}
-		// Serve half the promised bytes, then flush to force chunked encoding so the client sees a clean EOF instead of a Content-Length mismatch.
+
 		_, _ = w.Write(data[start : start+(end-start)/2])
 		w.(http.Flusher).Flush()
 	}))
@@ -178,7 +177,7 @@ func TestDownloadToFileMismatchedContentRangeFails(t *testing.T) {
 			return
 		}
 		if start > 0 {
-			start-- // lie about the span actually served
+			start--
 		}
 		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(data)))
 		w.WriteHeader(http.StatusPartialContent)

--- a/images/gc_test.go
+++ b/images/gc_test.go
@@ -46,7 +46,6 @@ func TestGCCollectSkipsRepublishedBlob(t *testing.T) {
 		TempDir:  dir,
 	})
 
-	// The publish lands between the (empty) snapshot and Collect.
 	if err := store.Update(ctx, func(idx *Index[gcTestEntry]) error {
 		idx.Images["ref1"] = &gcTestEntry{Digest: "deadbeef"}
 		return nil
@@ -60,7 +59,6 @@ func TestGCCollectSkipsRepublishedBlob(t *testing.T) {
 		t.Fatalf("republished blob removed: %v", removed)
 	}
 
-	// Once the ref is gone the same candidate collects.
 	if err := store.Update(ctx, func(idx *Index[gcTestEntry]) error {
 		delete(idx.Images, "ref1")
 		return nil
@@ -161,7 +159,6 @@ func TestGCCollectRespectsExternalPins(t *testing.T) {
 		t.Fatalf("externally pinned blob removed: %v", removed)
 	}
 
-	// The pin released: the same candidate collects.
 	pins = map[string]struct{}{}
 	if err := mod.Collect(ctx, []string{"deadbeef"}, ImageGCSnapshot{}); err != nil {
 		t.Fatal(err)

--- a/images/index_test.go
+++ b/images/index_test.go
@@ -12,19 +12,19 @@ func TestLookupOne(t *testing.T) {
 	if _, e, ok := LookupOne(images, "img:v1"); !ok || e.id != "sha256:aabb000011112222333344445555666a" {
 		t.Errorf("exact ref lookup failed: ok=%v", ok)
 	}
-	// Unique 16-hex digest prefix resolves.
+
 	if ref, _, ok := LookupOne(images, "aabb000011112222bbbb"); !ok || ref != "other:v1" {
 		t.Errorf("unique prefix: ok=%v ref=%q", ok, ref)
 	}
-	// Tag aliases of one digest are not ambiguous.
+
 	if _, e, ok := LookupOne(images, "sha256:aabb000011112222333344445555666a"); !ok || (*e).EntryID() != "sha256:aabb000011112222333344445555666a" {
 		t.Errorf("multi-tag single-digest must resolve: ok=%v", ok)
 	}
-	// 16-hex prefix spanning two distinct digests: past the minHexLen guard, must be refused by the cross-digest check.
+
 	if _, _, ok := LookupOne(images, "aabb000011112222"); ok {
 		t.Error("ambiguous cross-digest prefix must not resolve")
 	}
-	// Sub-minHexLen prefix never reaches prefix matching at all.
+
 	if _, _, ok := LookupOne(images, "aabb"); ok {
 		t.Error("short prefix must not resolve")
 	}
@@ -42,7 +42,6 @@ func TestDeleteByIDRejectsAmbiguousPrefix(t *testing.T) {
 		t.Fatalf("nothing may be deleted on ambiguity: deleted=%v remaining=%d", deleted, len(images))
 	}
 
-	// A digest shared only by tag aliases still sweeps all its refs.
 	deleted, err = deleteByID(t.Context(), "test.Delete", images, lookup, []string{"sha256:aabb000011112222333344445555666a"})
 	if err != nil {
 		t.Fatalf("single-digest delete: %v", err)

--- a/images/oci/oci.go
+++ b/images/oci/oci.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/projecteru2/core/log"
 	"golang.org/x/sync/singleflight"
@@ -52,7 +51,7 @@ func New(ctx context.Context, rootDir string, poolSize int, metaStore meta.Store
 			Store:      store,
 			Type:       typ,
 			LookupRefs: func(m map[string]*imageEntry, id string) []string { return images.LookupRefs(m, id, normalizeRef) },
-			Sizer:      imageSizer(cfg),
+			Sizer:      func(e *imageEntry) int64 { return e.Size },
 		},
 	}
 	return o, nil
@@ -60,14 +59,12 @@ func New(ctx context.Context, rootDir string, poolSize int, metaStore meta.Store
 
 func (o *OCI) Type() string { return typ }
 
-// Pull downloads an OCI image, extracts boot files, and converts each layer to EROFS concurrently.
 func (o *OCI) Pull(ctx context.Context, image string, _ bool, tracker progress.Tracker) error {
 	return images.SingleflightDo(ctx, &o.pullGroup, image, func() error {
 		return pull(ctx, o.conf, o.store, image, tracker)
 	})
 }
 
-// Import: each tar file becomes one EROFS layer in the order of the files slice.
 func (o *OCI) Import(ctx context.Context, name string, tracker progress.Tracker, file ...string) error {
 	return importTarLayers(ctx, o.conf, o.store, name, tracker, file...)
 }
@@ -76,7 +73,6 @@ func (o *OCI) ImportFromReader(ctx context.Context, name string, tracker progres
 	return importTarFromReader(ctx, o.conf, o.store, name, tracker, r)
 }
 
-// Config builds StorageConfig + BootConfig from layer digests; errors if any blob is missing.
 func (o *OCI) Config(ctx context.Context, vms []*types.VMConfig) (result [][]*types.StorageConfig, boot []*types.BootConfig, err error) {
 	err = o.store.View(ctx, func(idx *imageIndex) error {
 		result = make([][]*types.StorageConfig, len(vms))
@@ -120,30 +116,4 @@ func (o *OCI) Config(ctx context.Context, vms []*types.VMConfig) (result [][]*ty
 		return nil
 	})
 	return result, boot, err
-}
-
-func imageSizer(paths *Config) func(*imageEntry) int64 {
-	return func(e *imageEntry) int64 {
-		if e.Size > 0 {
-			return e.Size
-		}
-		// Fallback for index entries created before Size was cached.
-		var total int64
-		for _, layer := range e.Layers {
-			if info, err := os.Stat(paths.BlobPath(layer.Digest.Hex())); err == nil {
-				total += info.Size()
-			}
-		}
-		if e.KernelLayer != "" {
-			if info, err := os.Stat(paths.KernelPath(e.KernelLayer.Hex())); err == nil {
-				total += info.Size()
-			}
-		}
-		if e.InitrdLayer != "" {
-			if info, err := os.Stat(paths.InitrdPath(e.InitrdLayer.Hex())); err == nil {
-				total += info.Size()
-			}
-		}
-		return total
-	}
 }

--- a/images/op.go
+++ b/images/op.go
@@ -29,7 +29,6 @@ func (ops Ops[E]) Inspect(ctx context.Context, id string) (result *types.Image, 
 	return result, err
 }
 
-// List returns every image in the index.
 func (ops Ops[E]) List(ctx context.Context) (result []*types.Image, err error) {
 	err = ops.Store.View(ctx, func(idx *Index[E]) error {
 		result = listImages(idx.Images, ops.Type, ops.Sizer)
@@ -38,7 +37,7 @@ func (ops Ops[E]) List(ctx context.Context) (result []*types.Image, err error) {
 	return result, err
 }
 
-// Delete deletes entries from an index by ids and returns actually-removed refs; not-found ids are logged and skipped.
+// not-found ids are logged and skipped
 func (ops Ops[E]) Delete(ctx context.Context, ids []string) (deleted []string, err error) {
 	err = ops.Store.Update(ctx, func(idx *Index[E]) error {
 		var delErr error

--- a/images/op_test.go
+++ b/images/op_test.go
@@ -21,7 +21,7 @@ func TestSingleflightDoDetachesCanceledWaiter(t *testing.T) {
 		})
 		close(done)
 	}()
-	// The blocking flight must register first, or the canceled call could win the key and select its own instant result over the canceled ctx.
+
 	<-started
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -29,7 +29,7 @@ func TestSingleflightDoDetachesCanceledWaiter(t *testing.T) {
 	if err := SingleflightDo(ctx, &g, "k", func() error { return nil }); !errors.Is(err, context.Canceled) {
 		t.Errorf("canceled waiter err = %v, want context.Canceled", err)
 	}
-	// The shared work must still be running — unblock it so the goroutine exits.
+
 	close(block)
 	<-done
 }

--- a/lock/vmlock/gc_test.go
+++ b/lock/vmlock/gc_test.go
@@ -20,7 +20,7 @@ func TestGCModuleSweepsOnlyUnknownUnheldLocks(t *testing.T) {
 			defer l.Unlock(ctx) //nolint:errcheck
 			continue
 		}
-		// Recreate the file after the transient unlock removed it, standing in for a pre-transient install's residue.
+
 		if err := l.Unlock(ctx); err != nil {
 			t.Fatalf("seed unlock %s: %v", id, err)
 		}

--- a/lock/vmlock/shared_lease_unix_test.go
+++ b/lock/vmlock/shared_lease_unix_test.go
@@ -84,7 +84,6 @@ func TestSharedLeaseInheritanceSurvivesChildExit(t *testing.T) {
 	}
 }
 
-// The split regression: an exclusive transient release unlinks the inode a waiting lease acquired; the lease must rebind so a later exclusive still sees it.
 func TestSharedLeaseRebindsAfterExclusiveUnlink(t *testing.T) {
 	rootDir := t.TempDir()
 	ctx := t.Context()
@@ -107,7 +106,7 @@ func TestSharedLeaseRebindsAfterExclusiveUnlink(t *testing.T) {
 	select {
 	case err := <-errCh:
 		t.Fatalf("lease acquired despite the held exclusive: %v", err)
-	case <-time.After(20 * time.Millisecond): // the lease is blocked on the held exclusive
+	case <-time.After(20 * time.Millisecond):
 	}
 	if err := ex.Unlock(ctx); err != nil {
 		t.Fatal(err)

--- a/meta/contracttest/suite.go
+++ b/meta/contracttest/suite.go
@@ -385,7 +385,7 @@ func testEvents(t *testing.T, factory Factory) {
 	}
 }
 
-// testLogCursor asserts §9's log contract: committed Seq unique and strictly increasing, a rolled-back append never surfaces in Scan (its number may be reused or left as a gap), Scan(after) exclusive and in order.
+// testLogCursor asserts §9's log contract: committed Seq unique and strictly increasing across a rolled-back append.
 func testLogCursor(t *testing.T, factory Factory) {
 	ctx := t.Context()
 	s := factory(t, []string{nsAlpha})
@@ -418,25 +418,6 @@ func testLogCursor(t *testing.T, factory Factory) {
 	s3 := appendOne(3)
 	if s3 <= s2 {
 		t.Fatalf("seq %d not above last committed %d", s3, s2)
-	}
-
-	var got []int
-	var seqs []meta.Seq
-	err = s.View(ctx, []string{nsAlpha}, func(r meta.Reader) error {
-		return l.Scan(ctx, r, s1, func(seq meta.Seq, rec *record) error {
-			got = append(got, rec.N)
-			seqs = append(seqs, seq)
-			return nil
-		})
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 2 || got[0] != 2 || got[1] != 3 {
-		t.Fatalf("scan after %d: want [2 3], got %v (seqs %v)", s1, got, seqs)
-	}
-	if seqs[0] != s2 || seqs[1] != s3 {
-		t.Fatalf("scan seqs: want [%d %d], got %v", s2, s3, seqs)
 	}
 }
 

--- a/meta/json/multiprocess_test.go
+++ b/meta/json/multiprocess_test.go
@@ -21,7 +21,6 @@ const (
 	inverseOps     = 10
 )
 
-// TestMultiProcessCorrectness is the design §9 gate with real processes, not goroutines: every worker's acknowledged insert must be present afterwards, every failure a mapped taxonomy error, and the reopened store uncorrupted.
 func TestMultiProcessCorrectness(t *testing.T) {
 	if testing.Short() {
 		t.Skip("multi-process gate skipped in -short")
@@ -52,7 +51,6 @@ func TestMultiProcessCorrectness(t *testing.T) {
 	}
 }
 
-// TestMultiProcessWorker is the helper-process body; it only runs when re-invoked by TestMultiProcessCorrectness with the env set.
 func TestMultiProcessWorker(t *testing.T) {
 	dir := os.Getenv("META_MP_DIR")
 	if dir == "" {
@@ -77,7 +75,6 @@ func TestMultiProcessWorker(t *testing.T) {
 	}
 }
 
-// TestInverseScopeNoDeadlock is the §9 cross-process gate: mutually-inverse scopes (write alpha read beta vs write beta read alpha) storm concurrently and must never deadlock — the engine's fixed global lock order is the proof.
 func TestInverseScopeNoDeadlock(t *testing.T) {
 	if testing.Short() {
 		t.Skip("multi-process gate skipped in -short")
@@ -106,7 +103,6 @@ func TestInverseScopeNoDeadlock(t *testing.T) {
 	}
 }
 
-// TestInverseScopeWorker is the helper-process body for the inverse-scope gate.
 func TestInverseScopeWorker(t *testing.T) {
 	dir := os.Getenv("META_MP_DIR")
 	if dir == "" {
@@ -136,7 +132,6 @@ func TestInverseScopeWorker(t *testing.T) {
 	}
 }
 
-// TestAckedDurableSurvivesKill is the §9 durability gate: every insert the worker ACKed after a CommitDurable return must be present after SIGKILL.
 func TestAckedDurableSurvivesKill(t *testing.T) {
 	if testing.Short() {
 		t.Skip("multi-process gate skipped in -short")
@@ -178,7 +173,6 @@ func TestAckedDurableSurvivesKill(t *testing.T) {
 	}
 }
 
-// TestAckWorker is the helper-process body for the durability gate.
 func TestAckWorker(t *testing.T) {
 	dir := os.Getenv("META_MP_DIR")
 	if dir == "" {
@@ -199,7 +193,6 @@ func TestAckWorker(t *testing.T) {
 	}
 }
 
-// TestEventsExternalProcess is §9's cross-process signal gate for the json engine: another process's committed rename must reach subscribers here.
 func TestEventsExternalProcess(t *testing.T) {
 	if testing.Short() {
 		t.Skip("multi-process gate skipped in -short")
@@ -224,7 +217,6 @@ func TestEventsExternalProcess(t *testing.T) {
 	}
 }
 
-// TestEventsWriterWorker is the helper-process body.
 func TestEventsWriterWorker(t *testing.T) {
 	dir := os.Getenv("META_MP_DIR")
 	if dir == "" {
@@ -241,7 +233,6 @@ func TestEventsWriterWorker(t *testing.T) {
 	}
 }
 
-// stormWorkers is the design's 256-process gate by default; constrained CI runners dial it down via COCOON_STORM_WORKERS (full scale runs offline).
 func stormWorkers() int {
 	if v, err := strconv.Atoi(os.Getenv("COCOON_STORM_WORKERS")); err == nil && v > 0 {
 		return v

--- a/meta/json/raw.go
+++ b/meta/json/raw.go
@@ -22,7 +22,7 @@ func AppendStringSlice(dst []byte, s []string) ([]byte, error) {
 	return append(dst, ']'), nil
 }
 
-// AppendTable appends tbl as a compact JSON object with sorted keys, values verbatim — no intermediate value-map copy on the commit path.
+// AppendTable appends tbl as a compact JSON object with sorted keys, values verbatim.
 func AppendTable(dst []byte, m *Model, tbl string) ([]byte, error) {
 	t := m.tables[tbl]
 	dst = append(dst, '{')

--- a/meta/json/store.go
+++ b/meta/json/store.go
@@ -203,7 +203,7 @@ func (r *txReader) GetRaw(_ context.Context, ns, table, id string) (json.RawMess
 	return slices.Clone(raw), ok, nil
 }
 
-func (r *txReader) ScanRaw(_ context.Context, ns, table string, fn func(id string, raw json.RawMessage) error) error {
+func (r *txReader) ScanRaw(_ context.Context, ns, table string, fn meta.RawScanFunc) error {
 	l, ok := r.models[ns]
 	if !ok {
 		return fmt.Errorf("read %s: %w", ns, meta.ErrScope)

--- a/meta/json/store_test.go
+++ b/meta/json/store_test.go
@@ -19,7 +19,6 @@ func TestContract(t *testing.T) {
 }
 
 func TestContractForcedRetryEngine(t *testing.T) {
-	// The suite must also hold when EVERY closure is double-run.
 	contracttest.Run(t, func(t *testing.T, nss []string) meta.Store {
 		return contracttest.ForcedRetry(newStore(t, t.TempDir(), nss...))
 	})
@@ -57,7 +56,6 @@ func TestCommitAtomicityUnderCrash(t *testing.T) {
 			}
 			testCrashStep = nil
 
-			// Reopen as a fresh process would and require wholly-old or wholly-new.
 			s2 := newStore(t, dir, "alpha")
 			c2 := meta.NewCollection[map[string]int]("alpha", "records")
 			var a, b *map[string]int
@@ -114,7 +112,6 @@ func TestPrevRecovery(t *testing.T) {
 		t.Fatalf("recovered generation: %v, %v", got, err)
 	}
 
-	// A commit over a recovered main must not rotate the only good generation away.
 	v3 := map[string]int{"gen": 3}
 	if err := s2.Update(ctx, meta.Scope{Write: "alpha"}, meta.CommitDurable, func(w meta.Writer) error {
 		return c2.Replace(ctx, w, "a", &v3)
@@ -160,7 +157,6 @@ func TestExternalProcessEvents(t *testing.T) {
 	}
 	defer release()
 
-	// A second store over the same files stands in for an external process.
 	s2 := newStore(t, dir, "alpha")
 	c2 := meta.NewCollection[map[string]int]("alpha", "records")
 	v := map[string]int{"v": 1}
@@ -215,7 +211,7 @@ func TestOpenValidation(t *testing.T) {
 func TestEventsForcedOverflow(t *testing.T) {
 	ctx := t.Context()
 	dir := t.TempDir()
-	// Seam set before the notifier loop starts; reset runs after the store's Cleanup closes that loop (LIFO), so neither races the loop's reads.
+
 	testWatchErrs = make(chan struct{})
 	t.Cleanup(func() { testWatchErrs = nil })
 	s := newStore(t, dir, "alpha")
@@ -226,7 +222,6 @@ func TestEventsForcedOverflow(t *testing.T) {
 	}
 	defer release()
 
-	// Sever the dir watch: the commit below produces no fsnotify event.
 	if err := s.events.watcher.Remove(dir); err != nil {
 		t.Fatalf("remove watch: %v", err)
 	}
@@ -237,7 +232,7 @@ func TestEventsForcedOverflow(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	// Drain anything debounced from before the sever.
+
 	select {
 	case <-ch:
 	case <-time.After(200 * time.Millisecond):
@@ -345,7 +340,7 @@ func TestTrailingDataFallsBackToPrev(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	// Legacy json.Unmarshal rejected trailing bytes; the streaming decoder must too, so this main is corrupt and .prev is served.
+
 	main, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)

--- a/meta/json/tables.go
+++ b/meta/json/tables.go
@@ -36,7 +36,7 @@ func (c TableCodec) Encode(m *Model) ([]byte, error) {
 	return EncodeTables(m, c.Specs)
 }
 
-// DecodeTables loads specs' map fields into a fresh Model (sorted insertion, matching what encoding/json always wrote). Single streaming pass — a whole-file unmarshal into raw messages tokenizes the payload twice.
+// DecodeTables loads specs' map fields into a fresh Model (sorted insertion, matching what encoding/json always wrote).
 func DecodeTables(data []byte, specs []TableSpec) (*Model, error) {
 	m := NewModel()
 	if data == nil {

--- a/meta/log.go
+++ b/meta/log.go
@@ -1,12 +1,9 @@
 package meta
 
 import (
-	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
-	"slices"
-	"strconv"
 )
 
 // seqCursorID is the reserved in-table row holding the last assigned Seq.
@@ -54,41 +51,6 @@ func (l *Log[R]) Append(ctx context.Context, w Writer, rec *R, opts ...WriteOpt)
 		return 0, perr
 	}
 	return next, nil
-}
-
-// Scan streams committed entries with Seq strictly after the cursor, in order.
-func (l *Log[R]) Scan(ctx context.Context, r Reader, after Seq, fn func(Seq, *R) error) error {
-	type item struct {
-		seq Seq
-		raw json.RawMessage
-	}
-	var items []item
-	if err := r.ScanRaw(ctx, l.ns, l.table, func(id string, raw json.RawMessage) error {
-		if id == seqCursorID {
-			return nil
-		}
-		n, err := strconv.ParseUint(id, 10, 64)
-		if err != nil {
-			return fmt.Errorf("%s/%s id %q: %v: %w", l.ns, l.table, id, err, ErrCorrupt)
-		}
-		if Seq(n) > after {
-			items = append(items, item{Seq(n), raw})
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-	slices.SortFunc(items, func(a, b item) int { return cmp.Compare(a.seq, b.seq) })
-	for _, it := range items {
-		rec := new(R)
-		if err := json.Unmarshal(it.raw, rec); err != nil {
-			return fmt.Errorf("decode %s/%s seq %d: %w", l.ns, l.table, it.seq, err)
-		}
-		if err := fn(it.seq, rec); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func seqID(s Seq) string {

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -59,8 +59,11 @@ type Store interface {
 type Reader interface {
 	GetRaw(ctx context.Context, ns, table, id string) (json.RawMessage, bool, error)
 	// ScanRaw yields records in the engine's stable order (json: insertion).
-	ScanRaw(ctx context.Context, ns, table string, fn func(id string, raw json.RawMessage) error) error
+	ScanRaw(ctx context.Context, ns, table string, fn RawScanFunc) error
 }
+
+// RawScanFunc receives one raw record per ScanRaw visit.
+type RawScanFunc func(id string, raw json.RawMessage) error
 
 // Writer is the raw write SPI; relaxedOK mirrors the per-op RelaxedOK opt-in.
 type Writer interface {

--- a/meta/sqlite/events_test.go
+++ b/meta/sqlite/events_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cocoonstack/cocoon/meta"
 )
 
-// TestEventsExternalProcess is §9's cross-process signal gate: a commit by ANOTHER process must reach this process's subscribers.
 func TestEventsExternalProcess(t *testing.T) {
 	if testing.Short() {
 		t.Skip("multi-process gate skipped in -short")
@@ -32,7 +31,6 @@ func TestEventsExternalProcess(t *testing.T) {
 	waitEvent(t, ch, 8*time.Second, "external-process commit")
 }
 
-// TestEventsWriterWorker is the helper-process body.
 func TestEventsWriterWorker(t *testing.T) {
 	dir := os.Getenv("META_MP_DIR")
 	if dir == "" {
@@ -47,7 +45,6 @@ func TestEventsWriterWorker(t *testing.T) {
 	}
 }
 
-// TestEventsPoolChurn: reader-pool connections cycling under load must not blind the notifier — its pinned connection is untouched by the pool (§7).
 func TestEventsPoolChurn(t *testing.T) {
 	dir := t.TempDir()
 	s := newStore(t, dir, "alpha")
@@ -75,7 +72,6 @@ func TestEventsPoolChurn(t *testing.T) {
 	}
 }
 
-// TestEventsSeveredWatchPollFallback: a lost fsnotify watch must degrade to the change-token-confirmed safety poll, not a permanently missed change.
 func TestEventsSeveredWatchPollFallback(t *testing.T) {
 	dir := t.TempDir()
 	s := newStore(t, dir, "alpha")

--- a/meta/sqlite/init_test.go
+++ b/meta/sqlite/init_test.go
@@ -35,7 +35,7 @@ func TestFailedInitRestarts(t *testing.T) {
 
 func TestInitIdentityAtomicWithSchema(t *testing.T) {
 	path := filepath.Join(t.TempDir(), DBFileName)
-	// The retired pragmas-after-commit window: schema present, identity absent. It must refuse loudly, never strand or silently delete.
+
 	db, err := open(path, "FULL", true)
 	if err != nil {
 		t.Fatal(err)

--- a/meta/sqlite/maintenance_test.go
+++ b/meta/sqlite/maintenance_test.go
@@ -26,7 +26,7 @@ func TestBackupFidelity(t *testing.T) {
 			t.Fatalf("put %s: %v", id, err)
 		}
 	}
-	// Pre-snapshot marker: acked before backup, MUST be captured even while a writer keeps the WAL non-empty (§9 backup fidelity).
+
 	put("marker", `{"v":1}`)
 	stop := make(chan struct{})
 	go func() {
@@ -82,7 +82,7 @@ func TestBackupCrashSteps(t *testing.T) {
 		}
 		err := Backup(ctx, filepath.Join(dir, DBFileName), dest)
 		if step != "renamed" {
-			// Crash before rename: the published backup must be intact.
+
 			if !errors.Is(err, errCrash) {
 				t.Fatalf("step %s: want injected crash, got %v", step, err)
 			}
@@ -92,7 +92,7 @@ func TestBackupCrashSteps(t *testing.T) {
 		} else if !errors.Is(err, errCrash) {
 			t.Fatalf("step renamed: want injected crash, got %v", err)
 		}
-		// Rerun after every crash point must succeed (stale tmp cleared).
+
 		testBackupStep = nil
 		if err := Backup(ctx, filepath.Join(dir, DBFileName), dest); err != nil {
 			t.Fatalf("rerun after %s: %v", step, err)
@@ -156,7 +156,6 @@ func TestBusyCtxDeadline(t *testing.T) {
 	}
 }
 
-// TestBackupConcurrentSameDest pins the flock serialization: without it, a concurrent run's stale-tmp cleanup yanks the first run's tmp mid-verify and publishes an empty backup with a nil error.
 func TestBackupConcurrentSameDest(t *testing.T) {
 	ctx := t.Context()
 	dir := t.TempDir()

--- a/meta/sqlite/multiprocess_test.go
+++ b/meta/sqlite/multiprocess_test.go
@@ -25,13 +25,12 @@ const (
 	inverseOps     = 10
 )
 
-// TestMultiProcessCorrectness is §9's real-process storm for the sqlite engine: acknowledged inserts and their name rows all present, names referentially consistent, zero corruption on reopen.
 func TestMultiProcessCorrectness(t *testing.T) {
 	if testing.Short() {
 		t.Skip("multi-process gate skipped in -short")
 	}
 	dir := t.TempDir()
-	_ = newStore(t, dir, "alpha") // parent initializes once; workers only open
+	_ = newStore(t, dir, "alpha")
 	workers := stormWorkers()
 	cmds := contracttest.SpawnWorkers(t, workers, "TestMultiProcessWorker", func(w int) []string {
 		return []string{"META_MP_DIR=" + dir, "META_MP_WORKER=" + strconv.Itoa(w), fmt.Sprintf("META_MP_OPS=%d", mpOps)}
@@ -71,7 +70,6 @@ func TestMultiProcessCorrectness(t *testing.T) {
 	integrityCheck(t, dir)
 }
 
-// TestMultiProcessWorker is the helper-process body.
 func TestMultiProcessWorker(t *testing.T) {
 	dir := os.Getenv("META_MP_DIR")
 	if dir == "" {
@@ -95,7 +93,6 @@ func TestMultiProcessWorker(t *testing.T) {
 	}
 }
 
-// TestInverseScopeNoDeadlock storms mutually-inverse scopes across processes.
 func TestInverseScopeNoDeadlock(t *testing.T) {
 	if testing.Short() {
 		t.Skip("multi-process gate skipped in -short")
@@ -124,7 +121,6 @@ func TestInverseScopeNoDeadlock(t *testing.T) {
 	}
 }
 
-// TestInverseScopeWorker is the helper-process body.
 func TestInverseScopeWorker(t *testing.T) {
 	dir := os.Getenv("META_MP_DIR")
 	if dir == "" {
@@ -149,7 +145,6 @@ func TestInverseScopeWorker(t *testing.T) {
 	}
 }
 
-// TestKillStormAtomicity is §9's commit-atomicity-under-crash gate for the sqlite engine: SIGKILL sampled across WAL-append and commit-frame windows; every multi-record transaction must reopen wholly applied or wholly absent, every acked transaction wholly applied.
 func TestKillStormAtomicity(t *testing.T) {
 	if testing.Short() {
 		t.Skip("multi-process gate skipped in -short")
@@ -173,7 +168,7 @@ func TestKillStormAtomicity(t *testing.T) {
 			if id, ok := strings.CutPrefix(sc.Text(), "ACK "); ok {
 				acked[id] = struct{}{}
 				got++
-				// Kill at a round-varied depth so the SIGKILL lands in different WAL-append/commit windows.
+
 				if got >= 3+round*2 {
 					break
 				}
@@ -213,7 +208,6 @@ func TestKillStormAtomicity(t *testing.T) {
 	integrityCheck(t, dir)
 }
 
-// TestKillStormWorker writes multi-record durable transactions and acks each.
 func TestKillStormWorker(t *testing.T) {
 	dir := os.Getenv("META_MP_DIR")
 	if dir == "" {
@@ -237,7 +231,6 @@ func TestKillStormWorker(t *testing.T) {
 	}
 }
 
-// updateRetry retries on ErrBusy — the mapped, retryable-by-contract outcome under extreme oversubscription (§4); reconciliation still demands exact counts.
 func updateRetry(t *testing.T, s *Store, sc meta.Scope, fn func(meta.Writer) error) {
 	t.Helper()
 	for {

--- a/meta/sqlite/store.go
+++ b/meta/sqlite/store.go
@@ -307,7 +307,7 @@ func (h *txHandle) GetRaw(ctx context.Context, ns, table, id string) (json.RawMe
 	return data, true, nil
 }
 
-func (h *txHandle) ScanRaw(ctx context.Context, ns, table string, fn func(id string, raw json.RawMessage) error) error {
+func (h *txHandle) ScanRaw(ctx context.Context, ns, table string, fn meta.RawScanFunc) error {
 	if err := h.checkRead(ns); err != nil {
 		return err
 	}

--- a/metadata/fat12.go
+++ b/metadata/fat12.go
@@ -240,8 +240,8 @@ func blankSFN() [11]byte {
 
 // splitName splits an uppercased name into base and extension at the last dot; ext is "" when there is no dot.
 func splitName(upper string) (base, ext string) {
-	if dot := strings.LastIndex(upper, "."); dot >= 0 {
-		return upper[:dot], upper[dot+1:]
+	if base, ext, ok := strings.CutLast(upper, "."); ok {
+		return base, ext
 	}
 	return upper, ""
 }

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -139,7 +139,7 @@ func TestNetworkConfig_MultiNIC(t *testing.T) {
 	if !strings.Contains(out, "10.0.1.2/24") {
 		t.Errorf("second IP missing: %s", out)
 	}
-	// Gateway only on first NIC.
+
 	if !strings.Contains(out, "via: 10.0.0.1") {
 		t.Errorf("gateway missing: %s", out)
 	}
@@ -275,7 +275,6 @@ func TestUserData_NoMounts(t *testing.T) {
 }
 
 func TestUserData_MountsYAMLEscape(t *testing.T) {
-	// yamlQuote must double single quotes so a mount field can't break out of the YAML scalar.
 	cfg := &Config{
 		Mounts: []MountSpec{
 			{Device: "/dev/x", MountPoint: "/mnt/it's-here", FSType: "ext4", Options: "defaults"},

--- a/metering/file/file.go
+++ b/metering/file/file.go
@@ -21,7 +21,7 @@ type Recorder struct {
 
 // New opens or creates the append-only ledger at path.
 func New(path string) (*Recorder, error) {
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) //nolint:gosec
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) //nolint:gosec // operator-configured metering path
 	if err != nil {
 		return nil, fmt.Errorf("open ledger %s: %w", path, err)
 	}

--- a/metering/metalog/metalog.go
+++ b/metering/metalog/metalog.go
@@ -38,10 +38,3 @@ func (r *Recorder) Emit(ctx context.Context, e metering.Entry) {
 		log.WithFunc("metering.metalog.Recorder.Emit").Warnf(ctx, "append entry: %v", err)
 	}
 }
-
-// Scan streams committed entries with Seq strictly after cursor.
-func (r *Recorder) Scan(ctx context.Context, after meta.Seq, fn func(meta.Seq, *metering.Entry) error) error {
-	return r.store.View(ctx, []string{NamespaceName}, func(rd meta.Reader) error {
-		return r.log.Scan(ctx, rd, after, fn)
-	})
-}

--- a/metering/metalog/metalog_test.go
+++ b/metering/metalog/metalog_test.go
@@ -1,7 +1,9 @@
 package metalog
 
 import (
+	"encoding/json"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/cocoonstack/cocoon/meta"
@@ -9,7 +11,7 @@ import (
 	"github.com/cocoonstack/cocoon/metering"
 )
 
-func TestEmitScan(t *testing.T) {
+func TestEmitAppendsInOrder(t *testing.T) {
 	dir := t.TempDir()
 	s, err := metajson.Open(metajson.Namespace{
 		Name:     NamespaceName,
@@ -27,27 +29,23 @@ func TestEmitScan(t *testing.T) {
 	r.Emit(t.Context(), metering.Entry{Kind: metering.KindVMComputeStop, VMID: "vm1"})
 
 	var kinds []metering.Kind
-	var last meta.Seq
-	err = r.Scan(t.Context(), 0, func(seq meta.Seq, e *metering.Entry) error {
-		kinds = append(kinds, e.Kind)
-		last = seq
-		return nil
+	err = s.View(t.Context(), []string{NamespaceName}, func(rd meta.Reader) error {
+		return rd.ScanRaw(t.Context(), NamespaceName, TableEntries, func(id string, raw json.RawMessage) error {
+			if _, err := strconv.ParseUint(id, 10, 64); err != nil {
+				return nil
+			}
+			var e metering.Entry
+			if err := json.Unmarshal(raw, &e); err != nil {
+				return err
+			}
+			kinds = append(kinds, e.Kind)
+			return nil
+		})
 	})
 	if err != nil {
 		t.Fatalf("scan: %v", err)
 	}
 	if len(kinds) != 2 || kinds[0] != metering.KindVMComputeStart || kinds[1] != metering.KindVMComputeStop {
-		t.Fatalf("scan kinds: %v", kinds)
-	}
-
-	kinds = nil
-	if err := r.Scan(t.Context(), last, func(meta.Seq, *metering.Entry) error {
-		kinds = append(kinds, "dup")
-		return nil
-	}); err != nil {
-		t.Fatalf("scan after last: %v", err)
-	}
-	if len(kinds) != 0 {
-		t.Fatalf("scan after last seq must be empty, got %v", kinds)
+		t.Fatalf("appended kinds: %v", kinds)
 	}
 }

--- a/metering/metering_test.go
+++ b/metering/metering_test.go
@@ -31,7 +31,6 @@ func TestEntryJSONRoundTrip(t *testing.T) {
 }
 
 func TestKindWireFormat(t *testing.T) {
-	// Wire strings feed the external BQ schema; renaming any is a breaking change downstream.
 	cases := []struct {
 		got, want string
 	}{

--- a/network/bridge/gc_linux.go
+++ b/network/bridge/gc_linux.go
@@ -51,6 +51,9 @@ func GCModule(tapPrefix string) gc.Module[bridgeSnapshot] {
 		Collect: func(ctx context.Context, prefixes []string, _ bridgeSnapshot) error {
 			logger := log.WithFunc("gc.bridge")
 
+			if len(prefixes) == 0 {
+				return nil
+			}
 			orphanSet := make(map[string]struct{}, len(prefixes))
 			for _, p := range prefixes {
 				orphanSet[p] = struct{}{}

--- a/network/bridge/gc_linux_test.go
+++ b/network/bridge/gc_linux_test.go
@@ -19,10 +19,10 @@ func TestParseTAPName(t *testing.T) {
 
 		{tapPrefix: "bt", name: "wrong-prefix-0"},
 		{tapPrefix: "bt", name: "bt"},
-		{tapPrefix: "bt", name: "bt-0"}, // empty prefix
+		{tapPrefix: "bt", name: "bt-0"},
 		{tapPrefix: "bt", name: "bt12345678"},
 		{tapPrefix: "bt", name: ""},
-		{tapPrefix: "mt", name: "bt12345678-0"}, // another installation's TAP
+		{tapPrefix: "mt", name: "bt12345678-0"},
 	}
 	for _, tt := range tests {
 		label := tt.tapPrefix + "/" + tt.name

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/containernetworking/cni/libcni"
@@ -139,9 +140,9 @@ func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []n
 			}
 		}
 		if deleteTAP {
-			var idx int
-			if _, scanErr := fmt.Sscanf(rec.IfName, "eth%d", &idx); scanErr != nil {
-				logger.Warnf(ctx, "parse ifname %q for %s: %v (skip tap delete)", rec.IfName, vmID, scanErr)
+			idx, ok := ifIndex(rec.IfName)
+			if !ok {
+				logger.Warnf(ctx, "parse ifname %q for %s (skip tap delete)", rec.IfName, vmID)
 			} else if delErr := deleteTAPFn(nsPath, tapNameForVM(vmID, idx)); delErr != nil {
 				if recErr == nil {
 					recErr = fmt.Errorf("delete tap %s: %w", tapNameForVM(vmID, idx), delErr)
@@ -182,7 +183,7 @@ func (c *CNI) setLinkState(ctx context.Context, vmID string, up bool) error {
 	return setLinkStateFn(nsPath, ifNames, up)
 }
 
-// confListByName resolves a conflist by name; empty name returns the default (first alphabetically).
+// confListByName resolves a conflist by name; empty name returns the default (the alphabetically-first file).
 func (c *CNI) confListByName(name string) (*libcni.NetworkConfigList, error) {
 	if len(c.confLists) == 0 {
 		return nil, c.errNoConflist()
@@ -201,7 +202,7 @@ func (c *CNI) errNoConflist() error {
 	return fmt.Errorf("%w: no conflist found in %s", network.ErrNotConfigured, c.conf.CNIConfDir)
 }
 
-// loadConfLists loads all .conflist files from dir, returning name→conflist and the default (alphabetically first) name.
+// loadConfLists loads all .conflist files from dir, returning name→conflist and the name of the alphabetically-first file as the default.
 func loadConfLists(dir string) (map[string]*libcni.NetworkConfigList, string, error) {
 	files, err := libcni.ConfFiles(dir, []string{".conflist"})
 	if err != nil {
@@ -222,4 +223,14 @@ func loadConfLists(dir string) (map[string]*libcni.NetworkConfigList, string, er
 		defaultName = cmp.Or(defaultName, cl.Name)
 	}
 	return lists, defaultName, nil
+}
+
+func ifName(index int) string {
+	return "eth" + strconv.Itoa(index)
+}
+
+// ifIndex parses the NIC index back out of an ifName-scheme guest interface name.
+func ifIndex(name string) (int, bool) {
+	n, err := strconv.Atoi(strings.TrimPrefix(name, "eth"))
+	return n, err == nil && n >= 0 && strings.HasPrefix(name, "eth")
 }

--- a/network/cni/cni_test.go
+++ b/network/cni/cni_test.go
@@ -106,7 +106,7 @@ func TestLoadConfLists(t *testing.T) {
 
 	t.Run("default is alphabetically first by filename", func(t *testing.T) {
 		dir := t.TempDir()
-		// libcni.ConfFiles sorts by filename; lex order is 10-, 20-, 30-.
+
 		writeFile(t, filepath.Join(dir, "30-host.conflist"), hostNetConflist)
 		writeFile(t, filepath.Join(dir, "10-bridge.conflist"), bridgeConflist)
 		writeFile(t, filepath.Join(dir, "20-macvlan.conflist"), macvlanConflist)
@@ -176,13 +176,11 @@ func TestRemoveKeepsFailedNICRecords(t *testing.T) {
 	ctx := t.Context()
 	seedRecords(t, c, "vm1", "eth0", "eth1")
 
-	// eth1's CNI DEL fails: its record must survive the sweep so vm rm/GC/retry can still release the IPAM lease; eth0's record must be swept.
 	if err := c.Remove(ctx, "vm1", 0, 1); err == nil || !strings.Contains(err.Error(), "eth1") {
 		t.Fatalf("Remove err = %v, want eth1 failure", err)
 	}
 	assertRecordIDs(t, c, []string{"n-eth1"})
 
-	// Retry after the fault clears: the kept record lets Remove finish the release.
 	exec.failIf = ""
 	if err := c.Remove(ctx, "vm1", 1); err != nil {
 		t.Fatalf("retry Remove: %v", err)
@@ -195,7 +193,7 @@ func TestRemoveSweepsDuplicateIfNameRecords(t *testing.T) {
 	stubLifecycleSeams(t)
 
 	ctx := t.Context()
-	// A failed reclaim can leave two records for one ifname; Remove must tear down and sweep both (DEL is idempotent), not strand one as a phantom.
+
 	seedRecords(t, c, "vm1", "eth1")
 	if err := c.update(ctx, func(t *netTx) error {
 		return t.Put("n-eth1-dup", &networkRecord{ID: "n-eth1-dup", Type: "cni-bridge", VMID: "vm1", IfName: "eth1"})
@@ -217,7 +215,6 @@ func TestDeleteVMKeepsFailedNICRecords(t *testing.T) {
 	ctx := t.Context()
 	seedRecords(t, c, "vm1", "eth0", "eth1")
 
-	// A failed NIC release keeps its record AND the netns, surfaced as an error so rm reports the retryable leftover.
 	err := c.teardownProtocol(ctx, "vm1", nil, false)
 	if err == nil || !strings.Contains(err.Error(), "netns kept") {
 		t.Fatalf("deleteVM should surface the incomplete release, got: %v", err)
@@ -230,7 +227,6 @@ func TestDeleteVMZeroNICsWithoutConflist(t *testing.T) {
 	c.cniConf = nil
 	stubLifecycleSeams(t)
 
-	// A VM resized to 0 NICs has no lease needing a plugin DEL; a missing conflist must not wedge its netns removal.
 	if err := c.teardownProtocol(t.Context(), "vm1", nil, false); err != nil {
 		t.Fatalf("deleteVM with zero records: %v", err)
 	}
@@ -243,7 +239,6 @@ func TestVerifyDetectsMissingTAP(t *testing.T) {
 	tapPresentFn = func(_, tap string) error { return fmt.Errorf("tap %s: not found", tap) }
 	t.Cleanup(func() { statNetnsFn, tapPresentFn = origStat, origTap })
 
-	// A half-rolled-back recovery leaves the netns without TAPs; Verify must read that as broken, not healthy.
 	expected := []*types.NetworkConfig{{TAP: "tap-vm1-0"}}
 	if err := c.Verify(t.Context(), "vm1", expected); err == nil {
 		t.Fatal("Verify must fail when an expected TAP is missing")
@@ -262,14 +257,12 @@ func TestReclaimStaleNIC(t *testing.T) {
 	seedRecords(t, c, "vm1", "eth1")
 	rec := networkRecord{ID: "n-eth1", Type: "cni-bridge", VMID: "vm1", IfName: "eth1"}
 
-	// DEL failure keeps the record (nothing was released).
 	exec.failIf = "eth1"
 	if err := c.reclaimStaleNIC(ctx, "vm1", "/run/netns/vm1", rec); err == nil {
 		t.Fatal("reclaimStaleNIC: want error on failed DEL")
 	}
 	assertRecordIDs(t, c, []string{"n-eth1"})
 
-	// TAP-delete failure also keeps the record: sweeping would leave a live TAP that collides with the re-add's CreateTAP, with nothing left to retry it.
 	exec.failIf = ""
 	deleteTAPFn = func(string, string) error { return fmt.Errorf("device busy") }
 	if err := c.reclaimStaleNIC(ctx, "vm1", "/run/netns/vm1", rec); err == nil {
@@ -277,7 +270,6 @@ func TestReclaimStaleNIC(t *testing.T) {
 	}
 	assertRecordIDs(t, c, []string{"n-eth1"})
 
-	// Both succeed: the record is released and swept, freeing the index for re-add.
 	deleteTAPFn = func(string, string) error { return nil }
 	if err := c.reclaimStaleNIC(ctx, "vm1", "/run/netns/vm1", rec); err != nil {
 		t.Fatalf("reclaimStaleNIC: %v", err)
@@ -292,14 +284,12 @@ func TestAddFailsClosedOnStaleReclaim(t *testing.T) {
 	ctx := t.Context()
 	seedRecords(t, c, "vm1", "eth0")
 
-	// The stale record's DEL fails: Add must fail instead of double-allocating (lenient IPAM) or burying the root cause under the ADD failure (strict IPAM).
 	exec.failIf = "eth0"
 	if _, err := c.Add(ctx, "vm1", testVMCfg(), network.AddSpec{Index: 0}); err == nil || !strings.Contains(err.Error(), "reclaim stale NIC") {
 		t.Fatalf("Add err = %v, want reclaim failure", err)
 	}
 	assertRecordIDs(t, c, []string{"n-eth0"})
 
-	// Retry after the fault clears: reclaim succeeds, the fresh add replaces the record.
 	exec.failIf = ""
 	configs, err := c.Add(ctx, "vm1", testVMCfg(), network.AddSpec{Index: 0})
 	if err != nil {
@@ -332,7 +322,6 @@ func TestQuiesceSkipsMissingNetns(t *testing.T) {
 
 	seedRecords(t, c, "vm1", "eth0")
 
-	// A host reboot wipes every netns while the records survive; with no plumbing left, a stop's pending quiesce must settle instead of retrying forever.
 	if err := c.Quiesce(t.Context(), "vm1"); err != nil {
 		t.Fatalf("Quiesce with a missing netns: %v", err)
 	}
@@ -385,7 +374,6 @@ func TestQuiesceNoRecordsSkipsNetns(t *testing.T) {
 	setLinkStateFn = func(string, []string, bool) error { called = true; return nil }
 	t.Cleanup(func() { setLinkStateFn = origSet })
 
-	// A VM with no NIC records owns no plumbing to storm: never enter its netns.
 	if err := c.Quiesce(t.Context(), "ghost"); err != nil {
 		t.Fatalf("Quiesce: %v", err)
 	}
@@ -426,7 +414,8 @@ func newTestCNIWithStore(t *testing.T) (*CNI, *recordingExec) {
 func stubLifecycleSeams(t *testing.T) {
 	t.Helper()
 	origTAP, origNetns, origEnsure, origTC := deleteTAPFn, deleteNetnsFn, ensureNetnsFn, setupTCRedirectFn
-	origSet := setLinkStateFn
+	origSet, origStat := setLinkStateFn, statNetnsFn
+	statNetnsFn = func(string) (os.FileInfo, error) { return nil, nil }
 	deleteTAPFn = func(string, string) error { return nil }
 	deleteNetnsFn = func(context.Context, string) error { return nil }
 	ensureNetnsFn = func(string, string) (bool, error) { return false, nil }
@@ -434,7 +423,7 @@ func stubLifecycleSeams(t *testing.T) {
 	setLinkStateFn = func(string, []string, bool) error { return nil }
 	t.Cleanup(func() {
 		deleteTAPFn, deleteNetnsFn, ensureNetnsFn, setupTCRedirectFn = origTAP, origNetns, origEnsure, origTC
-		setLinkStateFn = origSet
+		setLinkStateFn, statNetnsFn = origSet, origStat
 	})
 }
 

--- a/network/cni/lifecycle.go
+++ b/network/cni/lifecycle.go
@@ -28,7 +28,7 @@ func (c *CNI) Prepare(_ context.Context, vmID string, _ *types.VMConfig) (string
 	}
 	nsName := c.conf.netnsName(vmID)
 	nsPath := c.conf.netnsPath(vmID)
-	if _, err := ensureNetns(nsName, nsPath); err != nil {
+	if _, err := ensureNetnsFn(nsName, nsPath); err != nil {
 		return "", fmt.Errorf("ensure netns %s: %w", nsName, err)
 	}
 	return nsPath, nil
@@ -102,7 +102,7 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 		}
 		kept := false
 		for _, a := range added {
-			ifn := fmt.Sprintf("eth%d", a.index)
+			ifn := ifName(a.index)
 			if delErr := c.cniDel(rctx, confList, vmID, nsPath, ifn); delErr != nil {
 				logger.Warnf(rctx, "rollback CNI DEL %s/%s: %v (record kept for GC)", vmID, ifn, delErr)
 				kept = true
@@ -110,7 +110,7 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 			}
 			// setupTCRedirect creates the TAP; it would leak if the netns persists.
 			if !createdNetns {
-				if delErr := deleteTAPInNetns(nsPath, tapNameForVM(vmID, a.index)); delErr != nil {
+				if delErr := deleteTAPFn(nsPath, tapNameForVM(vmID, a.index)); delErr != nil {
 					logger.Warnf(rctx, "rollback tap delete %s: %v (record kept for GC)", tapNameForVM(vmID, a.index), delErr)
 					kept = true
 					continue
@@ -125,7 +125,7 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 		}
 		// A kept record needs the netns for GC's retried DEL.
 		if createdNetns && !kept {
-			_ = deleteNetns(rctx, nsName)
+			_ = deleteNetnsFn(rctx, nsName)
 		}
 	}()
 
@@ -163,7 +163,7 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 				return err
 			}
 			if rec == nil { // intent vanished (concurrent sweep): reinsert
-				rec = &networkRecord{ID: f.recID, Type: confList.Name, VMID: vmID, IfName: fmt.Sprintf("eth%d", f.index)}
+				rec = &networkRecord{ID: f.recID, Type: confList.Name, VMID: vmID, IfName: ifName(f.index)}
 			}
 			if f.cfg.Network != nil {
 				rec.Network = *f.cfg.Network
@@ -191,7 +191,7 @@ func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 	}
 	wanted := make(map[string]bool, len(indices))
 	for _, i := range indices {
-		wanted[fmt.Sprintf("eth%d", i)] = true
+		wanted[ifName(i)] = true
 	}
 	// Pick every matching record, not one per ifname: a failed reclaim can leave duplicates, and DEL is idempotent — skipping one would strand a phantom.
 	picked := make([]networkRecord, 0, len(indices))
@@ -203,7 +203,7 @@ func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 		}
 	}
 	for _, i := range indices {
-		if ifName := fmt.Sprintf("eth%d", i); !found[ifName] {
+		if ifName := ifName(i); !found[ifName] {
 			return fmt.Errorf("nic %d (%s): no record", i, ifName)
 		}
 	}
@@ -235,7 +235,7 @@ func (c *CNI) stageNICIntents(ctx context.Context, confList *libcni.NetworkConfi
 		if spec.Existing != nil {
 			continue
 		}
-		ifName := fmt.Sprintf("eth%d", spec.Index)
+		ifName := ifName(spec.Index)
 		if rec, ok := stale[ifName]; ok {
 			// The index is reusable only after a full reclaim: proceeding would double-allocate on lenient IPAM plugins or bury the root cause on strict ones.
 			if rcErr := c.reclaimStaleNIC(ctx, vmID, nsPath, rec); rcErr != nil {
@@ -263,7 +263,7 @@ func (c *CNI) stageNICIntents(ctx context.Context, confList *libcni.NetworkConfi
 }
 
 func (c *CNI) nicRuntime(ctx context.Context, confList *libcni.NetworkConfigList, vmID, nsPath string, spec network.AddSpec) *libcni.RuntimeConf {
-	ifName := fmt.Sprintf("eth%d", spec.Index)
+	ifName := ifName(spec.Index)
 	rt := &libcni.RuntimeConf{ContainerID: vmID, NetNS: nsPath, IfName: ifName}
 	if spec.Existing != nil {
 		if delErr := c.cniDel(ctx, confList, vmID, nsPath, ifName); delErr != nil {
@@ -277,7 +277,7 @@ func (c *CNI) nicRuntime(ctx context.Context, confList *libcni.NetworkConfigList
 }
 
 func (c *CNI) provisionNIC(ctx context.Context, confList *libcni.NetworkConfigList, rt *libcni.RuntimeConf, vmID, nsPath string, vmCfg *types.VMConfig, spec network.AddSpec) (*types.NetworkConfig, error) {
-	ifName := fmt.Sprintf("eth%d", spec.Index)
+	ifName := ifName(spec.Index)
 	tapName := tapNameForVM(vmID, spec.Index)
 
 	cniResult, addErr := c.cniConf.AddNetworkList(ctx, confList, rt)

--- a/network/cni/teardown_test.go
+++ b/network/cni/teardown_test.go
@@ -24,12 +24,11 @@ func TestSubsetTeardownRecovery(t *testing.T) {
 	origNetns, origTAP, origStat := deleteNetnsFn, deleteTAPFn, statNetnsFn
 	deleteNetnsFn = func(context.Context, string) error { netnsRemoved++; return nil }
 	deleteTAPFn = func(_, tap string) error { tapsDeleted = append(tapsDeleted, tap); return nil }
-	statNetnsFn = func(string) (os.FileInfo, error) { return nil, nil } // netns present
+	statNetnsFn = func(string) (os.FileInfo, error) { return nil, nil }
 	t.Cleanup(func() { deleteNetnsFn, deleteTAPFn, statNetnsFn = origNetns, origTAP, origStat })
 	ctx := t.Context()
 	seedRecords(t, c, "vm1", "eth0", "eth1")
 
-	// Lease + deleting for the eth1 subset, then "crash" before any DEL ran.
 	ts := c.tombstones()
 	var leaseID string
 	if err := c.update(ctx, func(tx *netTx) error {
@@ -51,7 +50,7 @@ func TestSubsetTeardownRecovery(t *testing.T) {
 	if _, err := c.recoverTombstone(ctx, "vm1"); err != nil {
 		t.Fatalf("recover: %v", err)
 	}
-	// eth1's row is gone; eth0's row survives; no netns removal was attempted.
+
 	assertRecordIDs(t, c, []string{"n-eth0"})
 	for _, name := range exec.attempted {
 		if name == "eth0" {
@@ -61,7 +60,7 @@ func TestSubsetTeardownRecovery(t *testing.T) {
 	if netnsRemoved != 0 {
 		t.Fatalf("subset recovery removed the netns (%d removals)", netnsRemoved)
 	}
-	// Remove ran with deleteTAP=true; recovery restores it for exactly the subset's TAP and no other.
+
 	if want := []string{tapNameForVM("vm1", 1)}; !slices.Equal(tapsDeleted, want) {
 		t.Fatalf("subset recovery TAP deletions = %v, want %v", tapsDeleted, want)
 	}
@@ -165,7 +164,7 @@ func TestSubsetFailureKeepsTombstone(t *testing.T) {
 	if left == nil || left.Phase != tombstone.PhaseDeleting {
 		t.Fatalf("tombstone must stay in deleting: %+v", left)
 	}
-	// Fault clears; the retry converges.
+
 	exec.failIf = ""
 	if err := c.teardownProtocol(ctx, "vm3", []string{"n-eth1"}, false); err != nil {
 		t.Fatalf("retry: %v", err)

--- a/network/network.go
+++ b/network/network.go
@@ -22,6 +22,7 @@ type Network interface {
 	Type() string
 	Verify(ctx context.Context, vmID string, expected []*types.NetworkConfig) error
 	Prepare(ctx context.Context, vmID string, vmCfg *types.VMConfig) (string, error)
+	// Add attaches NICs; the CNI backend also writes the resolved conflist name into vmCfg.Network.
 	Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs ...AddSpec) ([]*types.NetworkConfig, error)
 	Remove(ctx context.Context, vmID string, indices ...int) error
 	Quiesce(ctx context.Context, vmID string) error

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -48,7 +48,7 @@ func TestValidateScope(t *testing.T) {
 func TestAddRecover(t *testing.T) {
 	existing := []*types.NetworkConfig{
 		{TAP: "tap0", NumQueues: 2},
-		nil, // persisted network_configs may carry null entries
+		nil,
 		{TAP: "tap2", NumQueues: 4},
 	}
 	specs := AddRecover(existing)

--- a/snapshot/localfile/export.go
+++ b/snapshot/localfile/export.go
@@ -53,7 +53,7 @@ func (lf *LocalFile) ExportToDir(ctx context.Context, ref, dir string) error {
 		}
 	}
 	// Fan out: snapshot dirs hold a few large files (memory, COW, data disks), so wall time is the longest copy, not the sum.
-	if _, err = utils.Map(ctx, names, func(_ context.Context, _ int, name string) (struct{}, error) {
+	if _, err = utils.Map(ctx, names, func(ctx context.Context, _ int, name string) (struct{}, error) {
 		if copyErr := utils.ReflinkCopy(ctx, filepath.Join(dir, name), filepath.Join(dataDir, name), utils.Sync); copyErr != nil {
 			return struct{}{}, fmt.Errorf("copy %s: %w", name, copyErr)
 		}

--- a/snapshot/localfile/gc_test.go
+++ b/snapshot/localfile/gc_test.go
@@ -198,7 +198,7 @@ func TestGCModule_LRURevalidatesAccess(t *testing.T) {
 	if len(ids) != 2 {
 		t.Fatalf("want 2 candidates, got %v", ids)
 	}
-	// A clone/export lands in the window and touches old1.
+
 	if err := lf.dbUpdate(ctx, func(idx *snapshotIndex) error {
 		idx.Snapshots[idx.Names["old1"]].LastAccessedAt = time.Now()
 		return nil
@@ -401,7 +401,6 @@ func TestGCModule_OrphanDirCleaned(t *testing.T) {
 }
 
 func TestGCModule_EvictRealRecordEmitsSnapStorageStop(t *testing.T) {
-	// LRU-evicting a real record must close its ledger interval (snap.storage.stop).
 	lf := newTestLF(t)
 	ctx := t.Context()
 
@@ -445,7 +444,6 @@ func TestGCModule_EvictRealRecordEmitsSnapStorageStop(t *testing.T) {
 }
 
 func TestGCModule_OrphanAndStalePendingDoNotEmit(t *testing.T) {
-	// Orphan and stale-pending records never opened a ledger interval, so GC must not emit a phantom stop.
 	lf := newTestLF(t)
 	ctx := t.Context()
 

--- a/snapshot/localfile/localfile.go
+++ b/snapshot/localfile/localfile.go
@@ -442,7 +442,7 @@ func (lf *LocalFile) lookupRecord(ctx context.Context, ref string, touch bool) (
 		}
 		if touch {
 			r.LastAccessedAt = time.Now()
-			if err := t.Put(id, r); err != nil {
+			if err := t.Put(id, r, meta.RelaxedOK); err != nil {
 				return err
 			}
 		}
@@ -450,7 +450,7 @@ func (lf *LocalFile) lookupRecord(ctx context.Context, ref string, touch bool) (
 		return nil
 	}
 	if touch {
-		return rec, lf.update(ctx, apply)
+		return rec, lf.touch(ctx, apply)
 	}
 	return rec, lf.view(ctx, apply)
 }

--- a/snapshot/localfile/localfile_test.go
+++ b/snapshot/localfile/localfile_test.go
@@ -89,7 +89,6 @@ func TestCreateAndDeleteEmitMetering(t *testing.T) {
 }
 
 func TestDeleteOneIdempotentDoesNotEmitTwice(t *testing.T) {
-	// Racing rm: the loser's closure sees a nil rec and must report success without emitting a phantom stop; deleteOne twice on one id simulates it.
 	rec := meteringcapture.New()
 	lf := newTestLFWithRecorder(t, rec)
 	ctx := t.Context()
@@ -134,7 +133,6 @@ func TestCreateFromDirDirectMatchesCreateLayout(t *testing.T) {
 		"cocoon.json":    []byte(`{"storage_configs":[]}`),
 	}
 
-	// A capture dir under the store root shares its filesystem, so the direct (rename) path is taken rather than the cross-fs streaming fallback.
 	srcDir := writeCaptureDir(t, filepath.Join(lf.conf.RootDir, "capture-src"), files)
 	id, ok, err := lf.CreateFromDir(ctx, &types.SnapshotConfig{
 		ID: testID(t), Name: "direct-snap", Hypervisor: "cloud-hypervisor",
@@ -155,7 +153,6 @@ func TestCreateFromDirDirectMatchesCreateLayout(t *testing.T) {
 		t.Fatalf("metering = %v, want one snap.storage.start", kinds(rec.Entries()))
 	}
 
-	// The on-disk layout is byte-for-byte what the tar path (Create) produces.
 	id2, err := lf.Create(ctx, &types.SnapshotConfig{
 		ID: testID(t), Name: "streamed-snap", Hypervisor: "cloud-hypervisor",
 	}, makeTar(t, files))
@@ -174,7 +171,6 @@ func TestCreateFromDirEXDEVFallsBack(t *testing.T) {
 	lf := newTestLFWithRecorder(t, rec)
 	ctx := t.Context()
 
-	// st_dev matches but rename EXDEVs (as on a bind mount): must roll back the pending record, leave srcDir intact, and report ok=false.
 	orig := osRename
 	osRename = func(string, string) error { return syscall.EXDEV }
 	t.Cleanup(func() { osRename = orig })
@@ -195,7 +191,7 @@ func TestCreateFromDirEXDEVFallsBack(t *testing.T) {
 	if _, statErr := os.Stat(srcDir); statErr != nil {
 		t.Errorf("srcDir removed on EXDEV fallback: %v", statErr)
 	}
-	// Check the index directly: Inspect hides pending records, so it cannot tell "rolled back" from "stale pending left behind", and a stale name reservation would fail the tar-fallback Create.
+
 	if err := lf.dbRead(ctx, func(idx *snapshotIndex) error {
 		if _, stale := idx.Snapshots[id]; stale {
 			return fmt.Errorf("pending record %s still in index", id)
@@ -472,7 +468,6 @@ func TestInspect_ByPrefix(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Use first 5 chars as prefix (IDs are 26-char base32).
 	prefix := id[:5]
 	s, err := lf.Inspect(ctx, prefix)
 	if err != nil {
@@ -764,7 +759,7 @@ func TestRestore_ConfigRoundtrip(t *testing.T) {
 		Config: types.Config{
 			Image:   "ubuntu:22.04",
 			CPU:     4,
-			Memory:  1 << 30, // 1 GiB
+			Memory:  1 << 30,
 			Storage: 10 << 30,
 		},
 	}
@@ -864,7 +859,6 @@ func TestRestore_CloseWaitsForGoroutine(t *testing.T) {
 	}
 
 	if err := rc.Close(); err != nil {
-		// A broken pipe is acceptable since the stream was not consumed, but it must not hang or panic.
 		t.Logf("Close returned (expected) error: %v", err)
 	}
 }
@@ -885,7 +879,7 @@ func TestRestore_DoubleCloseNoPanic(t *testing.T) {
 	}
 
 	rc.Close()
-	// Second close — must not deadlock or panic (idempotent via sync.Once).
+
 	rc.Close()
 }
 
@@ -1108,7 +1102,6 @@ func TestImport_CorruptGzipTrailerRejected(t *testing.T) {
 	tw.Close()
 	gw.Close()
 
-	// Flip a bit in the gzip ISIZE trailer: tar extraction still succeeds, so only the drain-to-EOF integrity check can catch it.
 	raw := buf.Bytes()
 	raw[len(raw)-1] ^= 0xff
 

--- a/snapshot/localfile/metans.go
+++ b/snapshot/localfile/metans.go
@@ -28,6 +28,13 @@ func (lf *LocalFile) update(ctx context.Context, fn func(*snapTx) error) error {
 	})
 }
 
+// touch commits relaxed: LastAccessedAt only steers GC's LRU, so a lost update costs one extra retention round, not correctness.
+func (lf *LocalFile) touch(ctx context.Context, fn func(*snapTx) error) error {
+	return lf.meta.Update(ctx, meta.Scope{Write: NamespaceName}, meta.CommitRelaxed, func(w meta.Writer) error {
+		return fn(lf.tx(ctx, w, w))
+	})
+}
+
 func (lf *LocalFile) tx(ctx context.Context, r meta.Reader, w meta.Writer) *snapTx {
 	return meta.NewNamedTx[snapshot.SnapshotRecord](ctx, NamespaceName, TableRecords, TableNames, r, w)
 }

--- a/snapshot/localfile/teardown.go
+++ b/snapshot/localfile/teardown.go
@@ -135,6 +135,7 @@ func (lf *LocalFile) recoverSnapTombstoneLocked(ctx context.Context, id string) 
 	if err := lf.finishSnapTeardown(ctx, id, leaseID, cl); err != nil {
 		return err
 	}
+	emitSnapStop(ctx, lf.metering, id, cl.Hypervisor)
 	log.WithFunc("localfile.recoverSnapTombstoneLocked").Warnf(ctx, "rolled forward interrupted delete of snapshot %s", id)
 	return nil
 }

--- a/snapshot/localfile/teardown.go
+++ b/snapshot/localfile/teardown.go
@@ -18,8 +18,9 @@ import (
 var ErrTombstoned = errors.New("snapshot is being deleted")
 
 type snapCleanup struct {
-	Name    string `json:"name,omitempty"`
-	DataDir string `json:"data_dir,omitempty"`
+	Name       string `json:"name,omitempty"`
+	DataDir    string `json:"data_dir,omitempty"`
+	Hypervisor string `json:"hypervisor,omitempty"`
 }
 
 func (lf *LocalFile) tombstones() *tombstone.Table {
@@ -49,8 +50,7 @@ func (lf *LocalFile) deleteSnapshotProtocol(ctx context.Context, id string, reva
 				skip = true
 				return nil
 			}
-			hyp = rec.Hypervisor
-			cl = snapCleanup{Name: rec.Name, DataDir: cmp.Or(rec.DataDir, lf.conf.SnapshotDataDir(id))}
+			cl = snapCleanup{Name: rec.Name, DataDir: cmp.Or(rec.DataDir, lf.conf.SnapshotDataDir(id)), Hypervisor: rec.Hypervisor}
 		}
 		var resumed *tombstone.Record
 		leaseID, resumed, err = ts.Acquire(ctx, t.Writer(), id, func() (tombstone.Payload, error) {
@@ -70,6 +70,7 @@ func (lf *LocalFile) deleteSnapshotProtocol(ctx context.Context, id string, reva
 	if skip {
 		return false, "", nil
 	}
+	hyp = cl.Hypervisor
 	if err := lf.update(ctx, func(t *snapTx) error {
 		return ts.MarkDeleting(ctx, t.Writer(), id, leaseID)
 	}); err != nil {

--- a/snapshot/localfile/teardown_test.go
+++ b/snapshot/localfile/teardown_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/cocoonstack/cocoon/meta/tombstone"
+	"github.com/cocoonstack/cocoon/metering"
+	meteringcapture "github.com/cocoonstack/cocoon/metering/capture"
 	"github.com/cocoonstack/cocoon/snapshot"
 )
 
@@ -31,7 +33,8 @@ func TestSharedLeaseEscalationLeasedRollsBack(t *testing.T) {
 }
 
 func TestSharedLeaseEscalationDeletingRollsForward(t *testing.T) {
-	lf := newTestLF(t)
+	rec := meteringcapture.New()
+	lf := newTestLFWithRecorder(t, rec)
 	id := makeExportableSnapshot(t, lf, "esc-deleting", map[string][]byte{"disk.raw": []byte("data")})
 	injectSnapTombstone(t, lf, id, tombstone.PhaseDeleting)
 
@@ -58,6 +61,10 @@ func TestSharedLeaseEscalationDeletingRollsForward(t *testing.T) {
 	if _, _, _, err := lf.DataDir(t.Context(), "esc-deleting"); !errors.Is(err, snapshot.ErrNotFound) {
 		t.Errorf("name still resolves after roll-forward: %v", err)
 	}
+	entries := rec.Entries()
+	if len(entries) == 0 || entries[len(entries)-1].Kind != metering.KindSnapStorageStop || entries[len(entries)-1].SnapshotID != id || entries[len(entries)-1].Reason != metering.ReasonSnapRemove {
+		t.Errorf("roll-forward did not close the storage interval: %+v", entries)
+	}
 }
 
 func injectSnapTombstone(t *testing.T, lf *LocalFile, id string, phase tombstone.Phase) {
@@ -69,7 +76,7 @@ func injectSnapTombstone(t *testing.T, lf *LocalFile, id string, phase tombstone
 		if err != nil {
 			return err
 		}
-		cl, err := tombstone.MarshalCleanup(snapCleanup{Name: rec.Name, DataDir: rec.DataDir})
+		cl, err := tombstone.MarshalCleanup(snapCleanup{Name: rec.Name, DataDir: rec.DataDir, Hypervisor: rec.Hypervisor})
 		if err != nil {
 			return err
 		}

--- a/types/vm_test.go
+++ b/types/vm_test.go
@@ -262,8 +262,8 @@ func validConfig() VMConfig {
 		Name: "test-vm",
 		Config: Config{
 			CPU:     2,
-			Memory:  1 << 30,  // 1 GiB
-			Storage: 20 << 30, // 20 GiB
+			Memory:  1 << 30,
+			Storage: 20 << 30,
 		},
 	}
 }

--- a/utils/batch_test.go
+++ b/utils/batch_test.go
@@ -195,7 +195,7 @@ func TestMap_Empty(t *testing.T) {
 
 func TestMap_PreservesOrder(t *testing.T) {
 	results, err := Map(t.Context(), []int{10, 20, 30, 40, 50}, func(_ context.Context, _, n int) (int, error) {
-		time.Sleep(time.Duration(50-n) * time.Millisecond) // reverse completion order
+		time.Sleep(time.Duration(50-n) * time.Millisecond)
 		return n * 2, nil
 	})
 	if err != nil {

--- a/utils/file_test.go
+++ b/utils/file_test.go
@@ -312,7 +312,7 @@ func TestRemoveMatching_RemoveAllError(t *testing.T) {
 	errs := RemoveMatching(t.Context(), dir, func(e os.DirEntry) bool {
 		return e.Name() == "protected"
 	})
-	// On some systems RemoveAll may succeed even without write, so just verify no panic.
+
 	_ = errs
 }
 

--- a/utils/http_test.go
+++ b/utils/http_test.go
@@ -23,7 +23,6 @@ func TestAPIError_Error(t *testing.T) {
 }
 
 func TestNewSocketHTTPClient_DialsSocket(t *testing.T) {
-	// Use /tmp directly — t.TempDir() path may exceed Unix socket limit (104 chars).
 	sockPath := filepath.Join("/tmp", fmt.Sprintf("cocoon-test-%d.sock", os.Getpid()))
 	t.Cleanup(func() { os.Remove(sockPath) })
 
@@ -252,7 +251,7 @@ func TestDoWithRetry_SuccessAfterRetries(t *testing.T) {
 	result, err := DoWithRetry(t.Context(), func() (int, error) {
 		calls++
 		if calls < 3 {
-			return 0, fmt.Errorf("transient error") // non-APIError → retryable
+			return 0, fmt.Errorf("transient error")
 		}
 		return 42, nil
 	})

--- a/utils/id_test.go
+++ b/utils/id_test.go
@@ -14,7 +14,6 @@ func TestGenerateID_Length(t *testing.T) {
 func TestGenerateID_Base32Chars(t *testing.T) {
 	id := GenerateID()
 	for _, c := range id {
-		// crypto/rand.Text uses RFC 4648 base32 alphabet (A-Z, 2-7).
 		if !((c >= 'A' && c <= 'Z') || (c >= '2' && c <= '7')) {
 			t.Errorf("non-base32 character: %c", c)
 		}

--- a/utils/magic.go
+++ b/utils/magic.go
@@ -1,6 +1,5 @@
 package utils
 
-// Magic byte prefixes shared by image/blob format sniffing.
 var (
 	Qcow2Magic = []byte{'Q', 'F', 'I', 0xfb}
 	GzipMagic  = []byte{0x1f, 0x8b}

--- a/utils/pidfd_linux.go
+++ b/utils/pidfd_linux.go
@@ -4,6 +4,8 @@ package utils
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"syscall"
 	"time"
 
@@ -11,6 +13,9 @@ import (
 )
 
 // OpenPidfd returns a pidfd for pid; the fd becomes readable once the process exits.
+// pidfdPollSlice bounds one poll so ctx cancellation is honored.
+const pidfdPollSlice = 100 * time.Millisecond
+
 func OpenPidfd(pid int) (int, error) { return unix.PidfdOpen(pid, 0) }
 
 // CloseFD closes a raw descriptor, ignoring a zero or negative one.
@@ -41,10 +46,10 @@ func terminateWithPidfd(ctx context.Context, pid int, binaryName, expectArg stri
 			return true, nil
 		}
 		_ = unix.PidfdSendSignal(fd, syscall.SIGKILL, nil, 0)
-		return true, waitDead(ctx, pid, killWaitTimeout)
+		return true, waitPidfd(ctx, fd, killWaitTimeout)
 	}
 
-	if err := waitDead(ctx, pid, gracePeriod); err == nil {
+	if err := waitPidfd(ctx, fd, gracePeriod); err == nil {
 		return true, nil
 	}
 
@@ -53,5 +58,27 @@ func terminateWithPidfd(ctx context.Context, pid int, binaryName, expectArg stri
 			return true, nil
 		}
 	}
-	return true, waitDead(ctx, pid, killWaitTimeout)
+	return true, waitPidfd(ctx, fd, killWaitTimeout)
+}
+
+// waitPidfd blocks until the pidfd reports exit; the kernel wakes the poll instead of a kill(0) loop.
+func waitPidfd(ctx context.Context, fd int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return fmt.Errorf("timeout after %s", timeout)
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		fds := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN}} //nolint:gosec // a pidfd is a small non-negative descriptor
+		n, err := unix.Poll(fds, int(min(remaining, pidfdPollSlice).Milliseconds()))
+		if err != nil && !errors.Is(err, unix.EINTR) {
+			return fmt.Errorf("poll pidfd: %w", err)
+		}
+		if n > 0 {
+			return nil
+		}
+	}
 }

--- a/utils/process_test.go
+++ b/utils/process_test.go
@@ -144,7 +144,7 @@ func TestVerifyProcessCmdline_InvalidPID(t *testing.T) {
 func TestVerifyProcessCmdline_WrongBinary(t *testing.T) {
 	pid := os.Getpid()
 	result := VerifyProcessCmdline(pid, "definitely-not-the-binary", "definitely-not-the-arg")
-	_ = result // Just verify no panic.
+	_ = result
 }
 
 func TestTerminateProcess_SleepProcess(t *testing.T) {
@@ -155,7 +155,6 @@ func TestTerminateProcess_SleepProcess(t *testing.T) {
 	pid := cmd.Process.Pid
 	waitForExec(t, pid, "sleep", "60")
 
-	// Reap the child in background: kill(pid, 0) keeps returning nil for a zombie and WaitFor would time out.
 	waitDone := make(chan struct{})
 	go func() {
 		_ = cmd.Wait()
@@ -188,7 +187,7 @@ func TestTerminateProcess_AlreadyDead(t *testing.T) {
 	_ = cmd.Wait()
 
 	ctx := t.Context()
-	// Should return nil — process doesn't exist, VerifyProcessCmdline returns false.
+
 	err := TerminateProcess(ctx, pid, "true", "true", 1*time.Second)
 	if err != nil {
 		t.Fatalf("TerminateProcess on dead process: %v", err)
@@ -197,7 +196,7 @@ func TestTerminateProcess_AlreadyDead(t *testing.T) {
 
 func TestTerminateProcess_InvalidPID(t *testing.T) {
 	ctx := t.Context()
-	// PID 0 → VerifyProcessCmdline returns false → return nil immediately.
+
 	if err := TerminateProcess(ctx, 0, "x", "x", time.Second); err != nil {
 		t.Errorf("expected nil for PID 0, got %v", err)
 	}
@@ -207,7 +206,6 @@ func TestTerminateProcess_InvalidPID(t *testing.T) {
 }
 
 func TestTerminateProcess_SIGTERMIgnored_FallsBackToKill(t *testing.T) {
-	// Traps SIGTERM so only SIGKILL can end it; the trailing "; :" stops bash from tail-exec'ing into sleep, which would rename argv0 and fail the "bash" cmdline check.
 	cmd := exec.Command("bash", "-c", `trap "" TERM; sleep 60; :`)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start: %v", err)
@@ -225,7 +223,6 @@ func TestTerminateProcess_SIGTERMIgnored_FallsBackToKill(t *testing.T) {
 		<-waitDone
 	}()
 
-	// Very short grace period — SIGTERM won't kill it, fallback to SIGKILL.
 	ctx := t.Context()
 	err := TerminateProcess(ctx, pid, "bash", "sleep", 200*time.Millisecond)
 	if err != nil {
@@ -240,7 +237,7 @@ func TestFindVMMByCmdline(t *testing.T) {
 		t.Skip("FindVMMByCmdline scans /proc — linux only")
 	}
 	marker := "cocoon-find-marker-" + strconv.Itoa(os.Getpid())
-	// "sleep 60 && :" is a compound command so sh can't tail-exec into sleep and lose the marker arg.
+
 	cmd := exec.Command("sh", "-c", "sleep 60 && :", marker)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start: %v", err)
@@ -290,7 +287,6 @@ func TestTerminateProcess_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	// Cancelled ctx: may return WaitFor's ctx error but must still attempt the kill.
 	_ = TerminateProcess(ctx, pid, "sleep", "60", 100*time.Millisecond)
 }
 

--- a/utils/reflink_test.go
+++ b/utils/reflink_test.go
@@ -57,7 +57,7 @@ func TestReflinkCopy_LargeFile(t *testing.T) {
 	src := filepath.Join(dir, "src")
 	dst := filepath.Join(dir, "dst")
 
-	want := bytes.Repeat([]byte("REFLINK"), 32768) // 224KB
+	want := bytes.Repeat([]byte("REFLINK"), 32768)
 	if err := os.WriteFile(src, want, 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/utils/sparse_linux_test.go
+++ b/utils/sparse_linux_test.go
@@ -19,7 +19,7 @@ func TestSparseCopy_AllSparse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	const size = 1 << 20 // 1MB
+	const size = 1 << 20
 	if err := f.Truncate(size); err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +43,7 @@ func TestSparseCopy_AllSparse(t *testing.T) {
 	}
 
 	blocks := fileBlocks(t, dst)
-	if blocks > 16 { // 16 * 512 = 8KB — generous threshold for metadata
+	if blocks > 16 {
 		t.Errorf("expected sparse dst, got %d blocks", blocks)
 	}
 }
@@ -53,7 +53,7 @@ func TestSparseCopy_PartialData(t *testing.T) {
 	src := filepath.Join(dir, "src")
 	dst := filepath.Join(dir, "dst")
 
-	const size = 1 << 20 // 1MB
+	const size = 1 << 20
 	f, err := os.Create(src)
 	if err != nil {
 		t.Fatal(err)
@@ -88,7 +88,7 @@ func TestSparseCopy_NonSparse(t *testing.T) {
 	src := filepath.Join(dir, "src")
 	dst := filepath.Join(dir, "dst")
 
-	data := bytes.Repeat([]byte("X"), 64*1024) // 64KB
+	data := bytes.Repeat([]byte("X"), 64*1024)
 	if err := os.WriteFile(src, data, 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +177,6 @@ func writeAt(t *testing.T, f *os.File, offset int64, data []byte) {
 	}
 }
 
-// fileBlocks returns the 512-byte block count allocated on disk.
 func fileBlocks(t *testing.T, path string) int64 {
 	t.Helper()
 	fi, err := os.Stat(path)

--- a/utils/sparse_test.go
+++ b/utils/sparse_test.go
@@ -57,7 +57,6 @@ func TestSparseCopy_LargeFile(t *testing.T) {
 	src := filepath.Join(dir, "src")
 	dst := filepath.Join(dir, "dst")
 
-	// 256KB of repeated data.
 	want := bytes.Repeat([]byte("ABCDEFGHIJKLMNOP"), 16384)
 	if err := os.WriteFile(src, want, 0o644); err != nil {
 		t.Fatal(err)

--- a/utils/stream.go
+++ b/utils/stream.go
@@ -32,7 +32,6 @@ func NewPipeStreamReader(pr *io.PipeReader, done <-chan error, cleanup func()) *
 	}
 }
 
-// Close drains the producer, runs cleanup, and returns any accumulated error.
 func (r *PipeStreamReader) Close() error {
 	return r.close()
 }

--- a/utils/tar_sparse_linux_test.go
+++ b/utils/tar_sparse_linux_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 )
 
-// Segment-map JSON over the cap → tarFileMaybeSparse falls back to non-sparse.
 func TestTarFileMaybeSparse_FallsBackOnLargeMap(t *testing.T) {
 	orig := maxSparseMapJSONSize
 	maxSparseMapJSONSize = 4 * 1024
@@ -45,7 +44,6 @@ func TestTarFileMaybeSparse_FallsBackOnLargeMap(t *testing.T) {
 	}
 }
 
-// Fallback round-trip: extracted file matches the original byte-for-byte (holes serialised as zeros).
 func TestTarFileMaybeSparse_FallbackRoundTrip(t *testing.T) {
 	orig := maxSparseMapJSONSize
 	maxSparseMapJSONSize = 4 * 1024
@@ -82,7 +80,6 @@ func TestTarFileMaybeSparse_FallbackRoundTrip(t *testing.T) {
 	}
 }
 
-// Small fragmentation still takes the sparse path; fallback only on PAX overflow.
 func TestTarFileMaybeSparse_PreservesSparsePathForSmallMaps(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "small-sparse")
@@ -119,7 +116,6 @@ func TestTarFileMaybeSparse_PreservesSparsePathForSmallMaps(t *testing.T) {
 	}
 }
 
-// writeSparseFile alternates numSegments data regions of blockSize with equal-sized holes.
 func writeSparseFile(t *testing.T, path string, numSegments, blockSize int) int64 {
 	t.Helper()
 	f, err := os.Create(path)

--- a/utils/tar_test.go
+++ b/utils/tar_test.go
@@ -102,7 +102,7 @@ func TestTarDir(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	// Subdirectory should be skipped.
+
 	if err := os.Mkdir(filepath.Join(dir, "subdir"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -244,7 +244,7 @@ func TestExtractTar_PathTraversal(t *testing.T) {
 func TestExtractTar_SkipsDotNames(t *testing.T) {
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
-	// Entry whose base name is "." — should be skipped.
+
 	tw.WriteHeader(&tar.Header{Name: ".", Size: 0, Typeflag: tar.TypeReg, Mode: 0o644})      //nolint:errcheck
 	tw.WriteHeader(&tar.Header{Name: "ok.txt", Size: 2, Typeflag: tar.TypeReg, Mode: 0o644}) //nolint:errcheck
 	tw.Write([]byte("ok"))                                                                   //nolint:errcheck
@@ -510,7 +510,6 @@ func TestExtractTar_Sparse_MixedWithRegularEntries(t *testing.T) {
 }
 
 func TestExtractFile_AllZeroBlocks(t *testing.T) {
-	// 12KB of zeros — extractFile should create holes via seek.
 	data := make([]byte, 12*1024)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "zeros.bin")
@@ -532,7 +531,6 @@ func TestExtractFile_AllZeroBlocks(t *testing.T) {
 }
 
 func TestExtractFile_NoZeroBlocks(t *testing.T) {
-	// Dense data — no blocks should become holes.
 	data := bytes.Repeat([]byte{0xBB}, 3*sparseBlockSize)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "dense.bin")
@@ -572,7 +570,6 @@ func TestExtractFile_MixedZeroAndData(t *testing.T) {
 }
 
 func TestExtractFile_EndsWithHole(t *testing.T) {
-	// 4KB data then 4KB zeros — file must be truncated to 8KB.
 	dataBlock := bytes.Repeat([]byte{0xDD}, sparseBlockSize)
 	zeroBlock := make([]byte, sparseBlockSize)
 	data := slices.Concat(dataBlock, zeroBlock)
@@ -612,7 +609,6 @@ func TestExtractFile_PartialBlock(t *testing.T) {
 }
 
 func TestExtractFile_PartialZeroBlock(t *testing.T) {
-	// Partial trailing block of zeros — still should produce correct size.
 	data := make([]byte, sparseBlockSize+500)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "pzero.bin")
@@ -668,7 +664,6 @@ func TestExtractFile_SingleByte(t *testing.T) {
 }
 
 func TestExtractFile_SingleZeroByte(t *testing.T) {
-	// A single zero byte — still a valid (tiny) file.
 	dir := t.TempDir()
 	path := filepath.Join(dir, "onezero.bin")
 
@@ -837,7 +832,6 @@ func makeTar(t *testing.T, files map[string][]byte) *bytes.Buffer {
 	return &buf
 }
 
-// makeTarSparse builds a tar with one COCOON.sparse PAX entry (stored bytes = segments, logical size = realSize).
 func makeTarSparse(t *testing.T, name string, realSize int64, segments []sparseSegment, data []byte) *bytes.Buffer {
 	t.Helper()
 	mapJSON, err := json.Marshal(segments)

--- a/utils/uuid_test.go
+++ b/utils/uuid_test.go
@@ -35,7 +35,7 @@ func TestUUIDv5_DifferentInputs(t *testing.T) {
 
 func TestUUIDv5_Version5(t *testing.T) {
 	id := UUIDv5("version-check")
-	// Version 5 UUID has '5' as the 13th character (position in 8-4-4-4-12).
+
 	if id[14] != '5' {
 		t.Errorf("expected version 5, got %c at position 14 in %q", id[14], id)
 	}

--- a/utils/watch_test.go
+++ b/utils/watch_test.go
@@ -43,7 +43,6 @@ func TestWatchFileDebounce(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Rapid successive writes should coalesce into one signal.
 	for i := range 5 {
 		if err := AtomicWriteFile(target, []byte{byte('0' + i)}, 0o644); err != nil {
 			t.Fatal(err)
@@ -81,7 +80,6 @@ func TestWatchFileCancel(t *testing.T) {
 	select {
 	case _, ok := <-ch:
 		if ok {
-			// Received a lingering signal before close — drain and wait for close.
 			select {
 			case _, ok := <-ch:
 				if ok {


### PR DESCRIPTION
Whole-repo quality round (2026-09-03): every production file read against the /code Style Self-Check (8 readers) and the judgment lenses (engine, storage, host); five commits, net −197 lines, comment lines +22/−205.

1. **perf** — `DataDir` bumped `LastAccessedAt` on every clone-from-snapshot through a durable transaction (an fsync on sqlite, serialized on the single durable writer); the value only steers GC's LRU, so the touch commits relaxed. `terminateWithPidfd` held a pidfd but waited for exit by polling `kill(pid, 0)` every millisecond; it polls the fd, so the kernel wakes it on exit (the VM stop path in every `vm rm`/release).
2. **cut** — `Log.Scan` and `metalog.Recorder.Scan` had no caller anywhere in the workspace (the metering log was write-only); the OCI sizer's stat fallback served index entries older than v0.1.0; the Firecracker clone renamed `cow.raw` onto itself (`runDir` and `COWRawPath` derive from the same id and config); `runningVMClientWithRecord`'s record was discarded at all three call sites.
3. **fix** — the cloud-image Range probe fetched one byte, below the four-byte sniff floor, so a URL serving an HTML error page was downloaded in full (up to 20 GiB) before `nonImageSignatures` rejected it (#137's Range half); a snapshot delete resumed from a tombstone emitted its storage-stop metering with an empty hypervisor; `Prepare` and the Add rollback bypassed three of the seven CNI test seams and the helper left `statNetnsFn` real, so `Remove`'s TAP deletion had no coverage on any platform; `gcTick` ignores a nil GC hook; the bridge GC skips its `LinkList` when it has no prefixes to match.
4. **docs** — docs/gc.md described a lock-all-modules cycle the code never had and a `nics=2/2` log field it never emits; docs/vm.md named a `REMOVED` event verb (the code emits `DELETED`) and the json engine's watch mechanism; docs/images.md and the flag help scoped `--force` to URL pulls (OCI tags are re-resolved every pull); docs/cli.md's tree shows the `--from-dir` positional.
5. **review** — eight verbs resolved a ref through `FindHypervisor` and immediately `Inspect`ed the same ref (the resolver's probe *is* that Inspect); `FindVM` returns the record. `LogPath` opened two views where `ResolveAndLoad` does one. `vm list`/`vm status --watch` reconciled every VM's state twice per render and the watch path never assigned it, so `THROTTLED` could contradict `STATE`. CNI interface names come from one helper and `ifIndex` rejects trailing garbage. Named scan-callback types replace three spelled-out func types. Comments shrink to the one-line budget; test files carry no comments (284 lines); six godocs on interface-implementing methods go. `core.ImageJSONNamespace` is exported for cocoon-macos, which lost `BaseConfig.JSONNamespace` in #207.

Held with measurement or reason: the CNI Add's four `networks.json` parses per run/clone (measured 0.1–1.0 % of a 230 ms copy-mode clone; both durable commits are required); `deleteOneLocked` re-walking `/proc` per stopped VM (reusing the pre-stop scan contradicts the re-observe-under-lock rule at supervisor.go:83); the `oci`/`cloudimg` GC method pairs (a shared base costs more lines than it saves); unexporting ten package-private hypervisor helpers (surface only; the layout churn is not worth it); the vmlock 2 ms retry (the same cadence as gofrs/flock, no cancellable primitive).

Gates: `GOWORK=off make lint` 0 issues on linux and darwin; `make fmt-check` clean; `asl ./...` clean on both GOOS; `GOWORK=off go test -race -count=1 ./...` green (the Linux-gated CNI/bridge/pidfd paths run in CI). Round diff: 106 files, +269/−466.