### PR TITLE
snapshot: preserve metering state through teardown

### DIFF
--- a/snapshot/localfile/gc.go
+++ b/snapshot/localfile/gc.go
@@ -208,7 +208,7 @@ func gcModule(lf *LocalFile, policy EvictionPolicy) gc.Module[snapshotGCSnapshot
 				}
 				_ = fl.Close() // lease file kept: unlinking a lock path splits exclusion
 				logEvictRow(ctx, logger, "collected", id, snap.records[id], snap.reasons[id])
-				if deleted && cleanup.EmitStop {
+				if deleted && !cleanup.Pending {
 					emitSnapStop(ctx, recorder, id, cleanup.Hypervisor)
 				}
 			}

--- a/snapshot/localfile/gc.go
+++ b/snapshot/localfile/gc.go
@@ -172,9 +172,9 @@ func gcModule(lf *LocalFile, policy EvictionPolicy) gc.Module[snapshotGCSnapshot
 					continue
 				}
 				// Candidacy revalidation under the lease: the reason picked at ReadDB must still hold, or a create/touch that landed in the window evicts the wrong snapshot.
-				pending, sawRecord := false, false
+				var sawRecord bool
 				revalidate := func(rec *snapshot.SnapshotRecord) bool {
-					pending, sawRecord = rec.Pending, true
+					sawRecord = true
 					switch snap.reasons[id] {
 					case "stale-pending":
 						return rec.Pending
@@ -189,7 +189,7 @@ func gcModule(lf *LocalFile, policy EvictionPolicy) gc.Module[snapshotGCSnapshot
 					}
 				}
 				// Record-backed candidates go through the phase protocol; a recordless leftover dir converges by plain removal.
-				deleted, hyp, err := lf.deleteSnapshotProtocol(ctx, id, revalidate)
+				deleted, cleanup, err := lf.deleteSnapshotProtocol(ctx, id, revalidate)
 				if err != nil {
 					_ = fl.Close()
 					errs = append(errs, fmt.Errorf("collect snapshot %s: %w", id, err))
@@ -208,9 +208,8 @@ func gcModule(lf *LocalFile, policy EvictionPolicy) gc.Module[snapshotGCSnapshot
 				}
 				_ = fl.Close() // lease file kept: unlinking a lock path splits exclusion
 				logEvictRow(ctx, logger, "collected", id, snap.records[id], snap.reasons[id])
-				// Skip orphan dirs and stale-pending — they never opened a snap.storage interval.
-				if deleted && !pending {
-					emitSnapStop(ctx, recorder, id, hyp)
+				if deleted && cleanup.EmitStop {
+					emitSnapStop(ctx, recorder, id, cleanup.Hypervisor)
 				}
 			}
 			return errors.Join(errs...)

--- a/snapshot/localfile/localfile.go
+++ b/snapshot/localfile/localfile.go
@@ -317,7 +317,7 @@ func (lf *LocalFile) deleteOne(ctx context.Context, id string) error {
 		}
 		return nil
 	}
-	if cleanup.EmitStop {
+	if !cleanup.Pending {
 		emitSnapStop(ctx, lf.metering, id, cleanup.Hypervisor)
 	}
 	// The lease file stays: flock syncs on the inode, so deleting it would split exclusion for a live waiter.

--- a/snapshot/localfile/localfile.go
+++ b/snapshot/localfile/localfile.go
@@ -307,7 +307,7 @@ func (lf *LocalFile) deleteOne(ctx context.Context, id string) error {
 	}
 	defer fl.Close() //nolint:errcheck
 	// A recordless leftover dir converges without a tombstone — nothing points at it.
-	deletedRecord, hypType, err := lf.deleteSnapshotProtocol(ctx, id, nil)
+	deletedRecord, cleanup, err := lf.deleteSnapshotProtocol(ctx, id, nil)
 	if err != nil {
 		return err
 	}
@@ -317,7 +317,9 @@ func (lf *LocalFile) deleteOne(ctx context.Context, id string) error {
 		}
 		return nil
 	}
-	emitSnapStop(ctx, lf.metering, id, hypType)
+	if cleanup.EmitStop {
+		emitSnapStop(ctx, lf.metering, id, cleanup.Hypervisor)
+	}
 	// The lease file stays: flock syncs on the inode, so deleting it would split exclusion for a live waiter.
 	return nil
 }

--- a/snapshot/localfile/teardown.go
+++ b/snapshot/localfile/teardown.go
@@ -21,7 +21,7 @@ type snapCleanup struct {
 	Name       string `json:"name,omitempty"`
 	DataDir    string `json:"data_dir,omitempty"`
 	Hypervisor string `json:"hypervisor,omitempty"`
-	EmitStop   bool   `json:"emit_stop,omitzero"`
+	Pending    bool   `json:"pending,omitzero"`
 }
 
 func (lf *LocalFile) tombstones() *tombstone.Table {
@@ -52,7 +52,7 @@ func (lf *LocalFile) deleteSnapshotProtocol(ctx context.Context, id string, reva
 			}
 			cl = snapCleanup{
 				Name: rec.Name, DataDir: cmp.Or(rec.DataDir, lf.conf.SnapshotDataDir(id)),
-				Hypervisor: rec.Hypervisor, EmitStop: !rec.Pending,
+				Hypervisor: rec.Hypervisor, Pending: rec.Pending,
 			}
 		}
 		var resumed *tombstone.Record
@@ -137,7 +137,7 @@ func (lf *LocalFile) recoverSnapTombstoneLocked(ctx context.Context, id string) 
 	if err := lf.finishSnapTeardown(ctx, id, leaseID, cl); err != nil {
 		return err
 	}
-	if cl.EmitStop {
+	if !cl.Pending {
 		emitSnapStop(ctx, lf.metering, id, cl.Hypervisor)
 	}
 	log.WithFunc("localfile.recoverSnapTombstoneLocked").Warnf(ctx, "rolled forward interrupted delete of snapshot %s", id)

--- a/snapshot/localfile/teardown.go
+++ b/snapshot/localfile/teardown.go
@@ -21,6 +21,7 @@ type snapCleanup struct {
 	Name       string `json:"name,omitempty"`
 	DataDir    string `json:"data_dir,omitempty"`
 	Hypervisor string `json:"hypervisor,omitempty"`
+	EmitStop   bool   `json:"emit_stop,omitzero"`
 }
 
 func (lf *LocalFile) tombstones() *tombstone.Table {
@@ -28,11 +29,10 @@ func (lf *LocalFile) tombstones() *tombstone.Table {
 }
 
 // deleteSnapshotProtocol runs the phase protocol for one snapshot under its held EXCLUSIVE lease; revalidate (optional) re-checks candidacy inside the lease transaction, and returning false skips without error.
-func (lf *LocalFile) deleteSnapshotProtocol(ctx context.Context, id string, revalidate func(*snapshot.SnapshotRecord) bool) (deleted bool, hyp string, err error) {
+func (lf *LocalFile) deleteSnapshotProtocol(ctx context.Context, id string, revalidate func(*snapshot.SnapshotRecord) bool) (deleted bool, cl snapCleanup, err error) {
 	ts := lf.tombstones()
 	var (
 		leaseID string
-		cl      snapCleanup
 		skip    bool
 	)
 	if err := lf.update(ctx, func(t *snapTx) error {
@@ -50,7 +50,10 @@ func (lf *LocalFile) deleteSnapshotProtocol(ctx context.Context, id string, reva
 				skip = true
 				return nil
 			}
-			cl = snapCleanup{Name: rec.Name, DataDir: cmp.Or(rec.DataDir, lf.conf.SnapshotDataDir(id)), Hypervisor: rec.Hypervisor}
+			cl = snapCleanup{
+				Name: rec.Name, DataDir: cmp.Or(rec.DataDir, lf.conf.SnapshotDataDir(id)),
+				Hypervisor: rec.Hypervisor, EmitStop: !rec.Pending,
+			}
 		}
 		var resumed *tombstone.Record
 		leaseID, resumed, err = ts.Acquire(ctx, t.Writer(), id, func() (tombstone.Payload, error) {
@@ -65,21 +68,20 @@ func (lf *LocalFile) deleteSnapshotProtocol(ctx context.Context, id string, reva
 		}
 		return json.Unmarshal(resumed.Payload.Cleanup, &cl)
 	}); err != nil {
-		return false, "", err
+		return false, snapCleanup{}, err
 	}
 	if skip {
-		return false, "", nil
+		return false, snapCleanup{}, nil
 	}
-	hyp = cl.Hypervisor
 	if err := lf.update(ctx, func(t *snapTx) error {
 		return ts.MarkDeleting(ctx, t.Writer(), id, leaseID)
 	}); err != nil {
-		return false, "", err
+		return false, snapCleanup{}, err
 	}
 	if err := lf.finishSnapTeardown(ctx, id, leaseID, cl); err != nil {
-		return false, "", err
+		return false, snapCleanup{}, err
 	}
-	return true, hyp, nil
+	return true, cl, nil
 }
 
 func (lf *LocalFile) finishSnapTeardown(ctx context.Context, id, leaseID string, cl snapCleanup) error {
@@ -135,7 +137,9 @@ func (lf *LocalFile) recoverSnapTombstoneLocked(ctx context.Context, id string) 
 	if err := lf.finishSnapTeardown(ctx, id, leaseID, cl); err != nil {
 		return err
 	}
-	emitSnapStop(ctx, lf.metering, id, cl.Hypervisor)
+	if cl.EmitStop {
+		emitSnapStop(ctx, lf.metering, id, cl.Hypervisor)
+	}
 	log.WithFunc("localfile.recoverSnapTombstoneLocked").Warnf(ctx, "rolled forward interrupted delete of snapshot %s", id)
 	return nil
 }

--- a/snapshot/localfile/teardown_test.go
+++ b/snapshot/localfile/teardown_test.go
@@ -111,7 +111,7 @@ func injectSnapTombstone(t *testing.T, lf *LocalFile, id string, phase tombstone
 			return err
 		}
 		cl, err := tombstone.MarshalCleanup(snapCleanup{
-			Name: rec.Name, DataDir: rec.DataDir, Hypervisor: rec.Hypervisor, EmitStop: !rec.Pending,
+			Name: rec.Name, DataDir: rec.DataDir, Hypervisor: rec.Hypervisor, Pending: rec.Pending,
 		})
 		if err != nil {
 			return err

--- a/snapshot/localfile/teardown_test.go
+++ b/snapshot/localfile/teardown_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cocoonstack/cocoon/metering"
 	meteringcapture "github.com/cocoonstack/cocoon/metering/capture"
 	"github.com/cocoonstack/cocoon/snapshot"
+	"github.com/cocoonstack/cocoon/types"
 )
 
 func TestSharedLeaseEscalationLeasedRollsBack(t *testing.T) {
@@ -67,6 +68,39 @@ func TestSharedLeaseEscalationDeletingRollsForward(t *testing.T) {
 	}
 }
 
+func TestDeletingPendingRecoverySkipsSnapStorageStop(t *testing.T) {
+	rec := meteringcapture.New()
+	lf := newTestLFWithRecorder(t, rec)
+	id := testID(t)
+	if _, err := lf.beginCreate(t.Context(), &types.SnapshotConfig{ID: id, Name: "pending", Hypervisor: "cloud-hypervisor"}); err != nil {
+		t.Fatalf("beginCreate: %v", err)
+	}
+	injectSnapTombstone(t, lf, id, tombstone.PhaseDeleting)
+
+	if err := lf.recoverSnapTombstone(t.Context(), id); err != nil {
+		t.Fatalf("recoverSnapTombstone: %v", err)
+	}
+	if entries := rec.Entries(); len(entries) != 0 {
+		t.Errorf("entries = %+v, want no stop for pending snapshot", entries)
+	}
+}
+
+func TestDeletePendingSkipsSnapStorageStop(t *testing.T) {
+	rec := meteringcapture.New()
+	lf := newTestLFWithRecorder(t, rec)
+	id := testID(t)
+	if _, err := lf.beginCreate(t.Context(), &types.SnapshotConfig{ID: id, Name: "pending", Hypervisor: "cloud-hypervisor"}); err != nil {
+		t.Fatalf("beginCreate: %v", err)
+	}
+
+	if _, err := lf.Delete(t.Context(), []string{id}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if entries := rec.Entries(); len(entries) != 0 {
+		t.Errorf("entries = %+v, want no stop for pending snapshot", entries)
+	}
+}
+
 func injectSnapTombstone(t *testing.T, lf *LocalFile, id string, phase tombstone.Phase) {
 	t.Helper()
 	ctx := t.Context()
@@ -76,7 +110,9 @@ func injectSnapTombstone(t *testing.T, lf *LocalFile, id string, phase tombstone
 		if err != nil {
 			return err
 		}
-		cl, err := tombstone.MarshalCleanup(snapCleanup{Name: rec.Name, DataDir: rec.DataDir, Hypervisor: rec.Hypervisor})
+		cl, err := tombstone.MarshalCleanup(snapCleanup{
+			Name: rec.Name, DataDir: rec.DataDir, Hypervisor: rec.Hypervisor, EmitStop: !rec.Pending,
+		})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

- persist whether a snapshot opened a storage metering interval in its teardown tombstone
- apply the same stop decision to direct deletion, GC collection, and interrupted-delete recovery
- cover stale-pending direct deletion and recovery without unmatched stop events

## Verification

- `gofmt -d snapshot/localfile/gc.go snapshot/localfile/localfile.go snapshot/localfile/teardown.go snapshot/localfile/teardown_test.go`
- `git diff --check`
- lint, tests, compilation, and builds were not run per the requested static-only scope