### PR TITLE
docs: cgroup_parent is per installation; document the cgroup GC lane

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,7 +79,7 @@ Config-file / env-only keys (no CLI flag):
 | Key          | Env Variable        | Default | Description                                                            |
 | ------------ | ------------------- | ------- | ---------------------------------------------------------------------- |
 | `pull_conns` | `COCOON_PULL_CONNS` | `8`     | Concurrent HTTP Range connections per cloud-image download (`image pull`); raise for fat pipes, lower to be gentle on the registry |
-| `cgroup_parent` | `COCOON_CGROUP_PARENT` | `cocoon.slice` | cgroup v2 slice under `/sys/fs/cgroup` holding the per-VM CPU scopes; see [CPU Isolation](vm.md#cpu-isolation-cgroup-v2) |
+| `cgroup_parent` | `COCOON_CGROUP_PARENT` | `cocoon.slice` | cgroup v2 slice under `/sys/fs/cgroup` holding the per-VM CPU scopes; GC removes any empty `vm-<id>.scope` under it that none of its own VMs owns, so co-hosted installations need distinct slices, as with `net_scope`; see [CPU Isolation](vm.md#cpu-isolation-cgroup-v2) |
 | `cgroup_cpus` | `COCOON_CGROUP_CPUS` | empty (all cores) | Host cpu list fencing the whole VM population (e.g. `0-14` reserves core 15 for the host); kernel cpu-list syntax |
 | `net_scope` | `COCOON_NET_SCOPE` | empty (legacy names) | Two alphanumerics keying this installation's host network families — bridge TAPs `<scope><vmid8>-<nic>`, CNI netns `<scope>-<vmid>` — so co-hosted installations never GC each other's; see [Host device namespaces](networking.md#host-device-namespaces) |
 | `ch_binary` | `COCOON_CH_BINARY` | `cloud-hypervisor` | cloud-hypervisor executable, path or `$PATH` name |

--- a/docs/gc.md
+++ b/docs/gc.md
@@ -40,6 +40,7 @@ Reasons:
 - **images (oci, cloudimg)**: `unreferenced`
 - **cni**: `orphan` (netns in this installation's `net_scope` family without active VM)
 - **bridge**: `orphan-tap` (TAP in this installation's `net_scope` family without active VM)
+- **cgroup**: `orphan-scope` (empty `vm-<id>.scope` under `cgroup_parent` that no VM record owns; scopes with live members are left alone)
 - **vmlock**: `orphan-lease` (lease file for a VM no backend knows)
 
 ### Snapshot LRU Eviction


### PR DESCRIPTION
Two co-hosted installations sharing one cgroup_parent make each other's empty vm-<id>.scope directories GC candidates, the same hazard net_scope already documents for host network names. The config table says so, and the GC page gains the cgroup lane (orphan-scope), which was implemented but undocumented.