### PR TITLE
review: comment budget, named func types, declaration layout

### DIFF
--- a/daemon/reconcile_test.go
+++ b/daemon/reconcile_test.go
@@ -69,7 +69,6 @@ func TestReconcileSkipsInconclusiveLiveness(t *testing.T) {
 	}
 }
 
-// A tombstoned record is not supervised as a live VM, but the daemon starts deletes of its own, so it must finish one a crash left mid-protocol.
 func TestReconcileResumesInterruptedDelete(t *testing.T) {
 	f := newFake().put(runningRec("vm1", 1))
 	f.tombstoned["vm1"] = struct{}{}
@@ -128,7 +127,6 @@ func TestReconcileCollectsOwnerlessCreating(t *testing.T) {
 	}
 }
 
-// A held ops lock is the create owner still working; the placeholder is not ownerless.
 func TestReconcileLeavesInFlightCreating(t *testing.T) {
 	f := newFake().put(&hypervisor.VMRecord{VM: types.VM{ID: "vm1", State: types.VMStateCreating}})
 	f.busy["vm1"] = struct{}{}
@@ -174,7 +172,6 @@ func TestHandleExitConvergesWatchedGeneration(t *testing.T) {
 	}
 }
 
-// An exit observed before a restart must not date or re-label the newer transition.
 func TestHandleExitDropsStaleGeneration(t *testing.T) {
 	f := newFake().put(runningRec("vm1", 9))
 	d := newTestDaemon(t, f)
@@ -209,7 +206,6 @@ func TestHandleExitIgnoresDeletedRecord(t *testing.T) {
 	}
 }
 
-// A VM the pass could not converge is degraded, not unready — a restart cannot fix it, and a busy ops lock is not a failure at all.
 func TestPassCountsDegradedVMsWithoutGoingUnready(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -243,7 +239,6 @@ func TestPassCountsDegradedVMsWithoutGoingUnready(t *testing.T) {
 	}
 }
 
-// A backend the daemon cannot even scan is the one case where restarting might help.
 func TestPassUnreadyWhenABackendCannotBeScanned(t *testing.T) {
 	f := newFake().put(runningRec("vm1", 1))
 	f.scanErr = fmt.Errorf("meta store unavailable")
@@ -260,7 +255,6 @@ type convergeCall struct {
 	gen  uint64
 }
 
-// fakeSupervisor scripts one backend's record set, liveness and lock state.
 type fakeSupervisor struct {
 	mu         sync.Mutex
 	records    map[string]*hypervisor.VMRecord
@@ -391,7 +385,6 @@ func (f *fakeSupervisor) ReconcileStaleCreate(_ context.Context, vmID string) (h
 	return hypervisor.StaleCreateCollected, nil
 }
 
-// lockState reads the scripted lock condition; the caller holds f.mu.
 func (f *fakeSupervisor) lockState(vmID string) (busy bool, err error) {
 	if f.lockErr != nil {
 		return false, f.lockErr

--- a/hypervisor/backend.go
+++ b/hypervisor/backend.go
@@ -123,6 +123,10 @@ type KillHook func(ctx context.Context, vmID string, rec *VMRecord) error
 // AfterExtractHook finalizes the restored record and returns the resulting VM.
 type AfterExtractHook func(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *VMRecord) (*types.VM, error)
 
+type ProcessHook func(ctx context.Context, rec *VMRecord, sockPath string, pid int) error
+
+type TransitionHook func(rec *VMRecord, hc *http.Client) error
+
 // RestoreSpec carries backend hooks for Backend.RestoreSequence.
 type RestoreSpec struct {
 	VMCfg            *types.VMConfig
@@ -149,13 +153,13 @@ type DirectRestoreSpec struct {
 type StartSpec struct {
 	RuntimeFiles []string
 	Launch       func(ctx context.Context, rec *VMRecord, sockPath string) (int, error)
-	PostLaunch   func(ctx context.Context, rec *VMRecord, sockPath string, pid int) error
+	PostLaunch   ProcessHook
 }
 
 // StopSpec carries StopOneSequence inputs.
 type StopSpec struct {
 	RuntimeFiles []string
-	Shutdown     func(ctx context.Context, rec *VMRecord, sockPath string, pid int) error
+	Shutdown     ProcessHook
 }
 
 // CreateSpec carries CreateSequence inputs.
@@ -169,8 +173,8 @@ type CreateSpec struct {
 
 // SnapshotSpec carries backend hooks for SnapshotSequence; the shared hc keeps HTTP keep-alive across pause/capture/resume.
 type SnapshotSpec struct {
-	Pause        func(rec *VMRecord, hc *http.Client) error
-	Resume       func(rec *VMRecord, hc *http.Client) error
+	Pause        TransitionHook
+	Resume       TransitionHook
 	Capture      func(rec *VMRecord, hc *http.Client, tmpDir string) error
 	AfterCapture func(rec *VMRecord, tmpDir string) error
 	BuildMeta    func(rec *VMRecord, tmpDir string) (*SnapshotMeta, error)

--- a/hypervisor/choreo_trace_test.go
+++ b/hypervisor/choreo_trace_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cocoonstack/cocoon/types"
 )
 
-// TestLegacyChoreographyTrace is the P0 differential gate (design §10): the migrated boundary must reproduce the legacy run's returned values, error identities and final bytes step for step.
 func TestLegacyChoreographyTrace(t *testing.T) {
 	raw, err := os.ReadFile(filepath.Join("testdata", "legacy-choreo-trace.json"))
 	if err != nil {

--- a/hypervisor/cloudhypervisor/console.go
+++ b/hypervisor/cloudhypervisor/console.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cocoonstack/cocoon/hypervisor"
 )
 
-// Console returns a caller-closed bidirectional stream to the VM console: console.sock (UEFI) or the CH-allocated PTY (OCI).
 func (ch *CloudHypervisor) Console(ctx context.Context, ref string) (io.ReadWriteCloser, error) {
 	logger := log.WithFunc("cloudhypervisor.Console")
 	id, rec, err := ch.ResolveAndLoad(ctx, ref)

--- a/hypervisor/cloudhypervisor/direct.go
+++ b/hypervisor/cloudhypervisor/direct.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cocoonstack/cocoon/types"
 )
 
-// DirectClone clones from a local snapshot dir. Per-type: hardlink memory-range-*, reflink/copy COW, plain copy metadata; cidata is regenerated.
 func (ch *CloudHypervisor) DirectClone(ctx context.Context, vmID string, vmCfg *types.VMConfig, net types.NetSetup, snapshotConfig *types.SnapshotConfig, srcDir string) (*types.VM, error) {
 	// The copy step's parse feeds cloneAfterExtractParsed: config.json is copied verbatim, so re-parsing the runDir copy would decode identical bytes.
 	var srcCfg *chVMConfig
@@ -28,7 +27,6 @@ func (ch *CloudHypervisor) DirectClone(ctx context.Context, vmID string, vmCfg *
 	})
 }
 
-// DirectRestore restores a VM in place from a local snapshot dir.
 func (ch *CloudHypervisor) DirectRestore(ctx context.Context, vmRef string, vmCfg *types.VMConfig, srcDir, sourceSnapshotID string) (*types.VM, error) {
 	var meta *hypervisor.SnapshotMeta
 	return ch.DirectRestoreSequence(ctx, vmRef, hypervisor.DirectRestoreSpec{

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -19,7 +19,6 @@ import (
 // ejectWaitTimeout bounds the wait for guest B0EJ; Linux acks < 1 s, Windows can take 10–20 s.
 const ejectWaitTimeout = 30 * time.Second
 
-// NetResize brings the VM's NIC count to spec.Target on a running CH VM.
 func (ch *CloudHypervisor) NetResize(ctx context.Context, vmRef string, spec netresize.Spec, plumbing netresize.Plumbing) (netresize.Result, error) {
 	if err := spec.Normalize(); err != nil {
 		return netresize.Result{}, err

--- a/hypervisor/cloudhypervisor/netresize_test.go
+++ b/hypervisor/cloudhypervisor/netresize_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cocoonstack/cocoon/types"
 )
 
-// TestReconcileOrphanNICs covers the interrupted-resize window: an unrecorded-MAC device must be ejected and its host TAP slot reclaimed (a leftover bridge TAP wedges every retry); recorded and boot-time (_net*) devices survive.
 func TestReconcileOrphanNICs(t *testing.T) {
 	hc, removed := newCHStubClient(t, []chNet{
 		{ID: "cocoon-net-aabbccddee01", MAC: "aa:bb:cc:dd:ee:01", TAP: "tapvm1beef-0"},
@@ -46,7 +45,6 @@ func TestReconcileOrphanNICs(t *testing.T) {
 	}
 }
 
-// TestReconcileOrphanNICsReclaimsSlotOnEjectTimeout pins the slow-guest path: a timed-out B0EJ wait still reclaims the orphan's TAP slot, since after a late eject no later reconcile could ever see it.
 func TestReconcileOrphanNICsReclaimsSlotOnEjectTimeout(t *testing.T) {
 	hc, removed := newCHStubClient(t, []chNet{
 		{ID: "cocoon-net-aabbccddee02", MAC: "aa:bb:cc:dd:ee:02", TAP: "tapvm1beef-1"},
@@ -71,7 +69,6 @@ func TestReconcileOrphanNICsReclaimsSlotOnEjectTimeout(t *testing.T) {
 	}
 }
 
-// TestResolveFailedPersist covers the persist commit-ambiguity window: a committed write keeps the device; only a conclusive miss tears down.
 func TestResolveFailedPersist(t *testing.T) {
 	ch := newTestCH(t)
 	ctx := t.Context()
@@ -106,7 +103,6 @@ func TestResolveFailedPersist(t *testing.T) {
 	}
 }
 
-// TestNetResizeRemoveResumesWithoutLiveDevice covers #104: a NIC the record still carries but CH already ejected (interrupted prior remove) must be truncated from the record, not wedge the retry.
 func TestNetResizeRemoveResumesWithoutLiveDevice(t *testing.T) {
 	ch := newTestCH(t)
 	ctx := t.Context()
@@ -146,7 +142,6 @@ func TestNICPersisted(t *testing.T) {
 	}
 }
 
-// TestConvergeOrphanedPause pins the interrupted-capture wedge: a save killed inside its pause window leaves CH Paused with nobody left to resume it.
 func TestConvergeOrphanedPause(t *testing.T) {
 	var (
 		mu      sync.Mutex
@@ -204,7 +199,6 @@ func (p *stubPlumbing) Remove(_ context.Context, _ string, indices ...int) error
 	return nil
 }
 
-// seedNetVM plants a record carrying one NIC through the exported surface.
 func seedNetVM(t *testing.T, ch *CloudHypervisor, id string, nc *types.NetworkConfig) {
 	t.Helper()
 	ctx := t.Context()
@@ -257,7 +251,6 @@ func newStubHTTPClient(t *testing.T, mux *http.ServeMux) *http.Client {
 	}}
 }
 
-// newCHStubClient serves vm.info and vm.remove-device over httptest; removed() snapshots the eject calls, and stickyIDs stay in the device tree after removal like a guest that never acks B0EJ.
 func newCHStubClient(t *testing.T, nets []chNet, stickyIDs ...string) (*http.Client, func() []string) {
 	t.Helper()
 	var mu sync.Mutex

--- a/hypervisor/cloudhypervisor/snapshot.go
+++ b/hypervisor/cloudhypervisor/snapshot.go
@@ -12,12 +12,10 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
-// Snapshot pauses, captures CH state+COW, resumes, and returns the capture dir.
 func (ch *CloudHypervisor) Snapshot(ctx context.Context, ref string) (*types.SnapshotConfig, string, error) {
 	return ch.SnapshotSequence(ctx, ref, ch.snapshotSpec(ctx))
 }
 
-// Hibernate captures like Snapshot but persists and then terminates the VMM inside the pause window instead of resuming.
 func (ch *CloudHypervisor) Hibernate(ctx context.Context, ref string, persist func(cfg *types.SnapshotConfig, srcDir string) error) error {
 	return ch.HibernateSequence(ctx, ref, hypervisor.HibernateSpec{
 		SnapshotSpec: ch.snapshotSpec(ctx),

--- a/hypervisor/cloudhypervisor/stop.go
+++ b/hypervisor/cloudhypervisor/stop.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
-// Stop shuts down each CH process: UEFI uses ACPI power-button; direct-boot uses vm.shutdown. Both fall back to SIGTERM→SIGKILL.
 func (ch *CloudHypervisor) Stop(ctx context.Context, refs []string) ([]string, error) {
 	return ch.StopAll(ctx, refs, ch.stopOne)
 }

--- a/hypervisor/firecracker/clone_test.go
+++ b/hypervisor/firecracker/clone_test.go
@@ -91,7 +91,6 @@ func TestPlaceholderCoalescesConcurrentRecordReads(t *testing.T) {
 	}
 }
 
-// Dead-source clones share the VM lock while GC and VM mutation remain excluded.
 func TestHoldBindableRedirectsCreatesPlaceholderAndSharesVMLock(t *testing.T) {
 	rootDir := t.TempDir()
 	runRoot := filepath.Join(rootDir, "run", "firecracker")
@@ -312,7 +311,6 @@ func TestRedirectBinds(t *testing.T) {
 	}
 }
 
-// A symlink source is unusable outright: the legacy redirect residue it could represent is no longer healed.
 func TestHoldBindableRedirectsRejectsSymlinkSource(t *testing.T) {
 	fc := newTestFC(t)
 	srcDir := fc.Conf.VMRunDir("SRC")

--- a/hypervisor/firecracker/direct.go
+++ b/hypervisor/firecracker/direct.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cocoonstack/cocoon/types"
 )
 
-// DirectClone clones from a local snapshot dir. Per-type: hardlink mem, reflink/copy COW, plain copy metadata.
 func (fc *Firecracker) DirectClone(ctx context.Context, vmID string, vmCfg *types.VMConfig, net types.NetSetup, snapshotConfig *types.SnapshotConfig, srcDir string) (*types.VM, error) {
 	spec := hypervisor.CloneSpec{VMCfg: vmCfg, Net: net, SnapshotConfig: snapshotConfig, AfterExtract: fc.cloneAfterExtract}
 	return fc.DirectCloneBase(ctx, vmID, spec, srcDir, func(dstDir, srcDir string) error {
@@ -16,7 +15,6 @@ func (fc *Firecracker) DirectClone(ctx context.Context, vmID string, vmCfg *type
 	})
 }
 
-// DirectRestore restores a VM in place from a local snapshot dir.
 func (fc *Firecracker) DirectRestore(ctx context.Context, vmRef string, vmCfg *types.VMConfig, srcDir, sourceSnapshotID string) (*types.VM, error) {
 	return fc.DirectRestoreSequence(ctx, vmRef, hypervisor.DirectRestoreSpec{
 		VMCfg:            vmCfg,

--- a/hypervisor/firecracker/snapshot.go
+++ b/hypervisor/firecracker/snapshot.go
@@ -15,12 +15,10 @@ const (
 	snapshotMemFile     = "mem"
 )
 
-// Snapshot pauses, captures vmstate+mem+COW, resumes, and returns the capture dir.
 func (fc *Firecracker) Snapshot(ctx context.Context, ref string) (*types.SnapshotConfig, string, error) {
 	return fc.SnapshotSequence(ctx, ref, fc.snapshotSpec(ctx))
 }
 
-// Hibernate captures like Snapshot but persists and then terminates the VMM inside the pause window instead of resuming.
 func (fc *Firecracker) Hibernate(ctx context.Context, ref string, persist func(cfg *types.SnapshotConfig, srcDir string) error) error {
 	return fc.HibernateSequence(ctx, ref, hypervisor.HibernateSpec{
 		SnapshotSpec: fc.snapshotSpec(ctx),

--- a/hypervisor/firecracker/start.go
+++ b/hypervisor/firecracker/start.go
@@ -23,7 +23,6 @@ import (
 
 const relayResponseTimeout = 5 * time.Second
 
-// Start launches FC, configures via REST, then InstanceStart.
 func (fc *Firecracker) Start(ctx context.Context, refs []string) ([]string, error) {
 	return fc.StartAll(ctx, refs, fc.startOne)
 }

--- a/hypervisor/firecracker/stop.go
+++ b/hypervisor/firecracker/stop.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
-// Stop shuts down each FC: SendCtrlAltDel + --timeout wait, or --force for immediate kill.
 func (fc *Firecracker) Stop(ctx context.Context, refs []string) ([]string, error) {
 	return fc.StopAll(ctx, refs, fc.stopOne)
 }

--- a/hypervisor/gc_test.go
+++ b/hypervisor/gc_test.go
@@ -102,7 +102,6 @@ func TestSweepStaleCaptureDirsCoversPersistedRunDir(t *testing.T) {
 	}
 }
 
-// A reserved dir swept as a VM run dir would get an ops.lock planted inside it by withOpsTryLock.
 func TestSweepDirsSkipsReservedNames(t *testing.T) {
 	snap := VMGCSnapshot{runDirs: []string{"db", CloneLocksDirName, "SOMEVM"}}
 	got := snap.sweepDirs("/root")

--- a/hypervisor/hibernate_test.go
+++ b/hypervisor/hibernate_test.go
@@ -115,7 +115,6 @@ type hibernateCalls struct {
 	terminated bool
 }
 
-// newHibernateTestVM seeds a running VM whose RunDir holds a live stub VMM process, so WithRunningVM lets the sequence proceed.
 func newHibernateTestVM(t *testing.T) (*Backend, string) {
 	t.Helper()
 	b, _ := newMeteringTestBackend(t)

--- a/hypervisor/inspect.go
+++ b/hypervisor/inspect.go
@@ -28,7 +28,6 @@ func (b *Backend) Inspect(ctx context.Context, ref string) (*types.VM, error) {
 	})
 }
 
-// List reads every record in one transaction and runs ToVM's per-VM file IO outside it, in parallel.
 func (b *Backend) List(ctx context.Context) ([]*types.VM, error) {
 	var recs []*VMRecord
 	if err := b.view(ctx, func(t *vmTx) error {

--- a/hypervisor/meta_test.go
+++ b/hypervisor/meta_test.go
@@ -23,7 +23,6 @@ var testVMTables = metajson.TableCodec{Specs: []metajson.TableSpec{
 	{Key: "tombstones", Table: tombstone.TableName, Optional: true},
 }}
 
-// TestLegacyDifferentialTrace replays the fixture op sequence over meta-json and requires bytes identical to what the legacy storage layer wrote (fixtures generated at master by cmd/fixturegen).
 func TestLegacyDifferentialTrace(t *testing.T) {
 	ctx := t.Context()
 	dir := t.TempDir()
@@ -92,7 +91,6 @@ func TestLegacyDifferentialTrace(t *testing.T) {
 	}
 }
 
-// TestCrossComponentVMLockPath asserts CH/FC (LockVMOps) and CNI (lock/vmlock) resolve one vmID to the same lock file; a stale backend-specific resolver would let CNI GC and VM lifecycle interleave.
 func TestCrossComponentVMLockPath(t *testing.T) {
 	ctx := t.Context()
 	b, _ := newMeteringTestBackend(t)
@@ -121,7 +119,6 @@ func TestCrossComponentVMLockPath(t *testing.T) {
 	}
 }
 
-// VMIndex mirrors the legacy whole-index shape for shim-based tests.
 type VMIndex struct {
 	VMs        map[string]*VMRecord `json:"vms"`
 	Names      map[string]string    `json:"names"`
@@ -137,7 +134,6 @@ func (idx *VMIndex) Init() {
 	}
 }
 
-// dbUpdate is the test-only whole-index shim: materialize, run fn, write the difference back.
 func (b *Backend) dbUpdate(ctx context.Context, fn func(*VMIndex) error) error {
 	return b.update(ctx, func(t *vmTx) error {
 		before, idx, err := materialize(t)
@@ -151,7 +147,6 @@ func (b *Backend) dbUpdate(ctx context.Context, fn func(*VMIndex) error) error {
 	})
 }
 
-// dbRead is the test-only whole-index read shim.
 func (b *Backend) dbRead(ctx context.Context, fn func(*VMIndex) error) error {
 	return b.view(ctx, func(t *vmTx) error {
 		_, idx, err := materialize(t)
@@ -162,7 +157,6 @@ func (b *Backend) dbRead(ctx context.Context, fn func(*VMIndex) error) error {
 	})
 }
 
-// addOrphanDir survives only for fixtures/shims; production writes cleanup intent through tombstone payloads.
 func (t *vmTx) addOrphanDir(dir string) error {
 	if _, ok, err := t.w.GetRaw(t.ctx, t.ns, TableOrphanDirs, dir); err != nil || ok {
 		return err
@@ -170,7 +164,6 @@ func (t *vmTx) addOrphanDir(dir string) error {
 	return t.w.PutRaw(t.ctx, t.ns, TableOrphanDirs, dir, json.RawMessage(`{}`), false)
 }
 
-// newTestMetaStore opens a meta store over the given index paths for one backend type.
 func newTestMetaStore(t *testing.T, typ, indexFile, lockPath string) *metajson.Store {
 	t.Helper()
 	store, err := metajson.Open(metajson.Namespace{Name: VMNamespaceName(typ), FilePath: indexFile, LockPath: lockPath, Codec: testVMTables})
@@ -181,7 +174,6 @@ func newTestMetaStore(t *testing.T, typ, indexFile, lockPath string) *metajson.S
 	return store
 }
 
-// testNamespace builds a standalone namespace under dir for shim-level tests.
 func testNamespace(t *testing.T, typ, dir string) *metajson.Store {
 	t.Helper()
 	store, err := metajson.Open(metajson.Namespace{Name: VMNamespaceName(typ), FilePath: filepath.Join(dir, "index.json"), LockPath: filepath.Join(dir, "index.lock"), Codec: testVMTables})

--- a/hypervisor/restore_test.go
+++ b/hypervisor/restore_test.go
@@ -272,7 +272,6 @@ func TestKillForRestoreFailureKeepsOriginContract(t *testing.T) {
 	}
 }
 
-// A corrupt persisted record (null storage/NIC entry) must fail preflight with a clean invariants error, not panic.
 func TestPrepareRestoreRejectsCorruptRecord(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/hypervisor/start_test.go
+++ b/hypervisor/start_test.go
@@ -103,7 +103,6 @@ func TestStartSequenceLaunchFailureSchedulesNetworkConvergence(t *testing.T) {
 	}
 }
 
-// seedStoppedVMWithDirs seeds a stopped record whose run/log dirs exist (PrepareStart requires them).
 func seedStoppedVMWithDirs(t *testing.T, b *Backend, id string) {
 	t.Helper()
 	seedVMRecord(t, b, id, 1, 1<<30, 10<<30, true)

--- a/hypervisor/state_test.go
+++ b/hypervisor/state_test.go
@@ -573,7 +573,6 @@ func TestPrepareStartRefusesCreating(t *testing.T) {
 	}
 }
 
-// TestForcedRetryStateOps is the design §10 gate: on a forced-retry engine (every closure runs twice) each metering entry must emit exactly once.
 func TestForcedRetryStateOps(t *testing.T) {
 	const typ = "test-hv"
 	dir := t.TempDir()
@@ -608,7 +607,6 @@ func TestForcedRetryStateOps(t *testing.T) {
 	}
 }
 
-// stubBackendConfig satisfies BackendConfig for metering-wiring tests; unused methods panic so accidental dependence shows up loud.
 type stubBackendConfig struct {
 	rootDir   string
 	indexFile string
@@ -635,7 +633,6 @@ func (c stubBackendConfig) CgroupParentDir() string { return filepath.Join(c.roo
 
 func (stubBackendConfig) CgroupCPUFence() string { return "" }
 
-// meteringStubConfig gives the metering stub a real VMRunDir so sequences can take the per-VM ops lock and MkdirTemp under it.
 type meteringStubConfig struct {
 	stubBackendConfig
 	vmRunRoot string

--- a/hypervisor/supervisor_test.go
+++ b/hypervisor/supervisor_test.go
@@ -39,7 +39,6 @@ func TestConvergeDeadMarksUnexpectedExit(t *testing.T) {
 	}
 }
 
-// A second convergence must not re-close the ledger: the generation it fences on has already advanced.
 func TestConvergeDeadIsIdempotent(t *testing.T) {
 	b, rec := newMeteringTestBackend(t)
 	ctx := t.Context()
@@ -76,7 +75,6 @@ func TestConvergeDeadFencesStaleGeneration(t *testing.T) {
 	}
 }
 
-// A record left Running by an older cocoon carries no open interval; the state must still converge, without an unmatched stop.
 func TestConvergeDeadStopsLegacyRunningWithoutInterval(t *testing.T) {
 	b, rec := newMeteringTestBackend(t)
 	ctx := t.Context()
@@ -140,7 +138,6 @@ func TestConvergeDeadKeepsPendingWhenQuiesceFails(t *testing.T) {
 	}
 }
 
-// The clear is fenced: a transition landing during the quiesce owns the pending flag it set.
 func TestQuiesceIfPendingFencedByGeneration(t *testing.T) {
 	b, _ := newMeteringTestBackend(t)
 	ctx := t.Context()
@@ -255,7 +252,6 @@ func TestReconcileStaleCreateCollectsAndFreesTheName(t *testing.T) {
 	}
 }
 
-// A held ops lock is the create owner still working; the record must survive untouched.
 func TestReconcileStaleCreateRefusesInFlightCreate(t *testing.T) {
 	b, _ := newMeteringTestBackend(t)
 	ctx := t.Context()
@@ -321,7 +317,6 @@ func TestTryLockVMOpsReportsBusyWithoutError(t *testing.T) {
 	}
 }
 
-// StoppedAt is the observation time, so a record predating the interval bookkeeping still gets one.
 func TestConvergeDeadDatesARecordWithNoOpenInterval(t *testing.T) {
 	b, rec := newMeteringTestBackend(t)
 	ctx := t.Context()
@@ -365,7 +360,6 @@ func TestUpdateStatesDatesAStoppedRecordThatWasRunning(t *testing.T) {
 	}
 }
 
-// A VM that never started must not be dated as though it had.
 func TestUpdateStatesLeavesACreatedRecordUndated(t *testing.T) {
 	b, _ := newMeteringTestBackend(t)
 	ctx := t.Context()
@@ -379,7 +373,6 @@ func TestUpdateStatesLeavesACreatedRecordUndated(t *testing.T) {
 	}
 }
 
-// seedPlumbedVM gives a running VM the persisted network state a stop must quiesce.
 func seedPlumbedVM(t *testing.T, b *Backend, id string) {
 	t.Helper()
 	seedRunningVM(t, b, id, 1, 1<<30, 10<<30)

--- a/hypervisor/teardown_test.go
+++ b/hypervisor/teardown_test.go
@@ -109,7 +109,6 @@ func TestTombstoneFencingABA(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Worker A leases and flips to deleting, then "dies".
 	var leaseA string
 	if err := b.update(ctx, func(tx *vmTx) error {
 		leaseA, err = ts.Lease(ctx, tx.w, "vmproto4", tombstone.Payload{Kind: tombstone.KindRecord, Mode: tombstone.ModeAggregate, Cleanup: cleanup})
@@ -156,7 +155,6 @@ func TestEntryGuardDisciplines(t *testing.T) {
 		t.Fatalf("leased guard must roll back and proceed: %v", err)
 	}
 
-	// deleting: the guard drives recovery to completion and refuses.
 	var lease string
 	if err := b.update(ctx, func(tx *vmTx) error {
 		lease, err = ts.Lease(ctx, tx.w, "vmproto5", tombstone.Payload{Kind: tombstone.KindRecord, Mode: tombstone.ModeAggregate, Cleanup: cleanup})
@@ -178,7 +176,6 @@ func TestEntryGuardDisciplines(t *testing.T) {
 	}
 }
 
-// TestLiveHolderKeepsLease is §9's negative fencing case: while A is alive and slow (ops lock held, tombstone deleting), B's sweep can neither take the lock nor steal the lease.
 func TestLiveHolderKeepsLease(t *testing.T) {
 	b, _ := newMeteringTestBackend(t)
 	ctx := t.Context()
@@ -227,7 +224,6 @@ func TestLiveHolderKeepsLease(t *testing.T) {
 	}
 }
 
-// TestPrepareStartRefusesMidDeleting is the §9 entry gate through the real start entrypoint: a dead worker's deleting tombstone drives recovery and refuses the boot.
 func TestPrepareStartRefusesMidDeleting(t *testing.T) {
 	b, _ := newMeteringTestBackend(t)
 	var netTorn []string
@@ -281,7 +277,6 @@ func TestPrepareStartRefusesMidDeleting(t *testing.T) {
 	}
 }
 
-// stubNetwork stands in for the injected host-networking seam; unset hooks are no-ops.
 type stubNetwork struct {
 	recover func(context.Context, *types.VM) error
 	quiesce func(context.Context, *types.VM) error
@@ -331,7 +326,6 @@ func seedProtoVM(t *testing.T, b *Backend, id string) *VMRecord {
 	return &rec
 }
 
-// entryGuardOnly exercises the entry guard the way an entrypoint does, discarding the record.
 func entryGuardOnly(ctx context.Context, b *Backend, id string) error {
 	_, err := b.entryGuard(ctx, id)
 	return err

--- a/hypervisor/utils.go
+++ b/hypervisor/utils.go
@@ -105,7 +105,6 @@ func (b *Backend) LogFilePath(logDir string) string {
 	return filepath.Join(logDir, b.Typ+".log")
 }
 
-// LogPath resolves ref → log path via the persisted LogDir (survives --log-dir change); falls back to current Conf for legacy records.
 func (b *Backend) LogPath(ctx context.Context, ref string) (string, error) {
 	id, rec, err := b.ResolveAndLoad(ctx, ref)
 	if err != nil {

--- a/hypervisor/utils_test.go
+++ b/hypervisor/utils_test.go
@@ -11,8 +11,7 @@ import (
 	"github.com/cocoonstack/cocoon/types"
 )
 
-// Under a pinned test process (taskset) NumCPU shrinks to the affinity mask while HostCPUCount must keep reporting the machine.
-func TestHostCPUCount(t *testing.T) {
+func TestHostCPUCountIgnoresAffinityMask(t *testing.T) {
 	got := HostCPUCount()
 	t.Logf("HostCPUCount=%d runtime.NumCPU=%d", got, runtime.NumCPU())
 	if got < runtime.NumCPU() {
@@ -200,7 +199,6 @@ func TestIsDataDiskFile(t *testing.T) {
 }
 
 func TestBuildBaseCmdline(t *testing.T) {
-	// Locks the cmdline format so a refactor of the shared builder can't silently shift kernel boot parameters for either backend.
 	const (
 		chPrefix = "console=hvc0 loglevel=3"
 		fcPrefix = "console=ttyS0 reboot=k loglevel=3 pci=off i8042.noaux 8250.nr_uarts=1"

--- a/meta/json/events.go
+++ b/meta/json/events.go
@@ -31,6 +31,24 @@ func (s *Store) Events(ctx context.Context) (<-chan struct{}, func(), error) {
 	return ch, func() { stop(); release() }, nil
 }
 
+type fileToken struct {
+	ino   uint64
+	size  int64
+	mtime int64
+}
+
+func statToken(path string) fileToken {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fileToken{}
+	}
+	tok := fileToken{size: info.Size(), mtime: info.ModTime().UnixNano()}
+	if st, ok := info.Sys().(*syscall.Stat_t); ok {
+		tok.ino = st.Ino
+	}
+	return tok
+}
+
 // tokens are touched only by newNotifier and the Run goroutine, never concurrently.
 type notifier struct {
 	b       *meta.Broadcaster
@@ -74,22 +92,4 @@ func (n *notifier) check() {
 	if changed {
 		n.b.Broadcast()
 	}
-}
-
-type fileToken struct {
-	ino   uint64
-	size  int64
-	mtime int64
-}
-
-func statToken(path string) fileToken {
-	info, err := os.Stat(path)
-	if err != nil {
-		return fileToken{}
-	}
-	tok := fileToken{size: info.Size(), mtime: info.ModTime().UnixNano()}
-	if st, ok := info.Sys().(*syscall.Stat_t); ok {
-		tok.ino = st.Ino
-	}
-	return tok
 }

--- a/snapshot/localfile/gc_test.go
+++ b/snapshot/localfile/gc_test.go
@@ -167,7 +167,6 @@ func TestGCModule_LRUEndToEnd(t *testing.T) {
 	}
 }
 
-// TestGCModule_LRURevalidatesAccess pins design §5 step 2: a snapshot touched between ReadDB and Collect must survive the stale candidate list.
 func TestGCModule_LRURevalidatesAccess(t *testing.T) {
 	lf := newTestLF(t)
 	ctx := t.Context()
@@ -484,7 +483,6 @@ func TestGCModule_OrphanAndStalePendingDoNotEmit(t *testing.T) {
 	}
 }
 
-// TestGCCollectsFreshPendingWithFreeLease pins the ownerless proof: a dead save's pending record is reclaimed on the next pass however young — the free build lease is the proof, not an age gate.
 func TestGCCollectsFreshPendingWithFreeLease(t *testing.T) {
 	lf := newTestLF(t)
 	ctx := t.Context()
@@ -516,7 +514,6 @@ func TestGCCollectsFreshPendingWithFreeLease(t *testing.T) {
 	}
 }
 
-// TestGCSkipsPendingHeldByLiveBuild pins the other half of the proof: a save still holding its build lease must not lose its pending record to GC.
 func TestGCSkipsPendingHeldByLiveBuild(t *testing.T) {
 	lf := newTestLF(t)
 	ctx := t.Context()

--- a/snapshot/localfile/localfile_test.go
+++ b/snapshot/localfile/localfile_test.go
@@ -262,7 +262,6 @@ func TestRollbackCreateSurvivesCanceledContext(t *testing.T) {
 	}
 }
 
-// TestNameOwnerSeesPendingReservation pins what a killed save leaves behind: the pending record still holds the name, so Inspect reports not-found while insertRecord rejects the reuse; the save preflight resolves through the index for exactly this reason.
 func TestNameOwnerSeesPendingReservation(t *testing.T) {
 	lf := newTestLF(t)
 	ctx := t.Context()
@@ -1539,7 +1538,6 @@ func makeExportableSnapshot(t *testing.T, lf *LocalFile, name string, files map[
 	return id
 }
 
-// testSnapNamespace mirrors the composition root's snapshots declaration.
 func testSnapNamespace(conf *config.Config) metajson.Namespace {
 	cfg := NewConfig(conf)
 	return metajson.Namespace{Name: NamespaceName, FilePath: cfg.IndexFile(), LockPath: cfg.IndexLock(), Codec: testSnapTables}

--- a/snapshot/localfile/meta_shim_test.go
+++ b/snapshot/localfile/meta_shim_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cocoonstack/cocoon/snapshot"
 )
 
-// TestLegacyDifferentialTrace replays the fixture op sequence over meta-json and requires byte-identical output to the legacy storage layer's writes.
 func TestLegacyDifferentialTrace(t *testing.T) {
 	ctx := t.Context()
 	dir := t.TempDir()
@@ -81,7 +80,6 @@ func TestLegacyDifferentialTrace(t *testing.T) {
 	}
 }
 
-// snapshotIndex mirrors the legacy top-level DB shape for shim-based tests.
 type snapshotIndex struct {
 	Snapshots map[string]*snapshot.SnapshotRecord `json:"snapshots"`
 	Names     map[string]string                   `json:"names"`

--- a/types/vm_test.go
+++ b/types/vm_test.go
@@ -9,7 +9,7 @@ func TestValidate(t *testing.T) {
 	tests := []struct {
 		name    string
 		modify  func(*VMConfig)
-		wantErr string // substring; empty = expect nil
+		wantErr string
 	}{
 		{
 			name:   "valid minimal config",

--- a/utils/process_test.go
+++ b/utils/process_test.go
@@ -66,17 +66,16 @@ func TestWriteReadPIDFile_Roundtrip_LargePID(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "large.pid")
 
-	// Max PID on Linux is typically 4194304 (2^22).
-	const largePID = 4194304
-	if err := WritePIDFile(path, largePID); err != nil {
+	const linuxMaxPID = 4194304
+	if err := WritePIDFile(path, linuxMaxPID); err != nil {
 		t.Fatal(err)
 	}
 	got, err := ReadPIDFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != largePID {
-		t.Errorf("PID: got %d, want %d", got, largePID)
+	if got != linuxMaxPID {
+		t.Errorf("PID: got %d, want %d", got, linuxMaxPID)
 	}
 }
 
@@ -247,7 +246,6 @@ func TestFindVMMByCmdline(t *testing.T) {
 		_ = cmd.Wait()
 	}()
 
-	// Poll briefly: cmdline is written by execve, so the parent may scan before /proc/<pid>/cmdline reflects argv.
 	var pids []int
 	for range 50 {
 		got, err := FindVMMByCmdline("sh", marker)
@@ -261,7 +259,7 @@ func TestFindVMMByCmdline(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	if len(pids) != 1 || pids[0] != cmd.Process.Pid {
-		t.Errorf("FindVMMByCmdline: got %v, want [%d]", pids, cmd.Process.Pid)
+		t.Errorf("FindVMMByCmdline never matched the execed cmdline: got %v, want [%d]", pids, cmd.Process.Pid)
 	}
 
 	if got, _ := FindVMMByCmdline("definitely-no-such-binary", marker); len(got) != 0 {
@@ -290,12 +288,11 @@ func TestTerminateProcess_ContextCancelled(t *testing.T) {
 	_ = TerminateProcess(ctx, pid, "sleep", "60", 100*time.Millisecond)
 }
 
-// waitForExec parks until the child's execve lands: cmd.Start returns pre-exec, and TerminateProcess declines a mismatched cmdline (#87 race).
 func waitForExec(t *testing.T, pid int, binaryName, expectArg string) {
 	t.Helper()
 	if err := WaitFor(t.Context(), 5*time.Second, time.Millisecond, func() (bool, error) {
 		return VerifyProcessCmdline(pid, binaryName, expectArg), nil
 	}); err != nil {
-		t.Fatalf("child never execed into %s: %v", binaryName, err)
+		t.Fatalf("child never execed into %s, so TerminateProcess would decline the mismatched cmdline (#87): %v", binaryName, err)
 	}
 }


### PR DESCRIPTION
Three review-only commits. No behavior change.

**review: comment budget — interface-method godocs and test comments**
- Drops the one-line godoc from 15 interface-implementing methods on `Backend`, `CloudHypervisor` and `Firecracker`. Each was verified against its interface (`Hypervisor`, `Direct`, `Hibernator`, `netresize.Resizer`); the interface documents the contract.
- Removes every non-directive comment from `_test.go` files under `hypervisor/`, `utils/`, `types/`, `daemon/` and `snapshot/localfile/` (58 comments, AST-identified so string literals were not touched). `//nolint` and `//go:build` directives are untouched.
- Where a comment carried a fact its test name did not, the fact moved into the name or an assertion message rather than into another comment:
  - `TestHostCPUCount` renamed to `TestHostCPUCountIgnoresAffinityMask`.
  - `largePID` renamed to `linuxMaxPID`.
  - The `FindVMMByCmdline` poll assertion now names the execve wait; `waitForExec`'s fatal message now carries the mismatched-cmdline race (#87).

**review: named func types in hypervisor specs**
- `SnapshotSpec.Pause` and `Resume` shared one inline func type, as did `StartSpec.PostLaunch` and `StopSpec.Shutdown`. Each shape is now declared once as `TransitionHook` and `ProcessHook`, joining the existing hook-type cluster in `hypervisor/backend.go`.

**review: layout — vocabulary types ahead of their consumers**
- `fileToken` is method-less and consumed only by `notifier`, but sat below `notifier`'s method block. It moves ahead of `notifier` together with its constructor `statToken`.

Gates, all from the worktree root with `GOWORK=off`:

```
==> golangci-lint GOOS=linux
0 issues.
==> golangci-lint GOOS=darwin
0 issues.

golangci-lint fmt --diff ./...   exit=0
make fmt-check                   exit=0
asl ./...                        exit=0
GOOS=linux asl ./...             exit=0
go test -race -count=1 -timeout 15m ./...   exit=0  (34 ok, 0 FAIL)
```

Comment delta per commit (`git diff -U0 HEAD~1 -- '*.go'`), added vs removed:

| commit | added | removed |
|---|---|---|
| comment budget | 0 | 72 |
| named func types | 0 | 0 |
| layout | 0 | 0 |