### PR TITLE
fix: COCOON_LOG_LEVEL env binding, log rotation decode, GC reason field

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/go-viper/mapstructure/v2"
 	"github.com/projecteru2/core/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -87,9 +86,9 @@ func newRootCmd() *cobra.Command {
 	viper.SetDefault("cgroup_cpus", "")
 	viper.SetDefault("net_scope", "")
 	viper.SetDefault("log.level", "info")
-	viper.SetDefault("log.max_size", 500)
-	viper.SetDefault("log.max_age", 28)
-	viper.SetDefault("log.max_backups", 3)
+	viper.SetDefault("log.maxsize", 500)
+	viper.SetDefault("log.maxage", 28)
+	viper.SetDefault("log.maxbackups", 3)
 
 	base := cmdcore.BaseHandler{ConfProvider: func() *config.Config { return conf }}
 
@@ -117,7 +116,7 @@ func initConfig(ctx context.Context) error {
 	}
 
 	conf = &config.Config{}
-	if err := viper.Unmarshal(conf, matchSnakeCase); err != nil {
+	if err := viper.Unmarshal(conf); err != nil {
 		return fmt.Errorf("parse config: %w", err)
 	}
 	if err := conf.Validate(); err != nil {
@@ -130,10 +129,4 @@ func initConfig(ctx context.Context) error {
 	setupErr := log.SetupLog(ctx, conf.Log, "")
 	os.Stdout = origStdout
 	return setupErr
-}
-
-func matchSnakeCase(c *mapstructure.DecoderConfig) {
-	c.MatchName = func(mapKey, fieldName string) bool {
-		return strings.EqualFold(strings.ReplaceAll(mapKey, "_", ""), strings.ReplaceAll(fieldName, "_", ""))
-	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/projecteru2/core/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -116,7 +117,7 @@ func initConfig(ctx context.Context) error {
 	}
 
 	conf = &config.Config{}
-	if err := viper.Unmarshal(conf); err != nil {
+	if err := viper.Unmarshal(conf, matchSnakeCase); err != nil {
 		return fmt.Errorf("parse config: %w", err)
 	}
 	if err := conf.Validate(); err != nil {
@@ -129,4 +130,10 @@ func initConfig(ctx context.Context) error {
 	setupErr := log.SetupLog(ctx, conf.Log, "")
 	os.Stdout = origStdout
 	return setupErr
+}
+
+func matchSnakeCase(c *mapstructure.DecoderConfig) {
+	c.MatchName = func(mapKey, fieldName string) bool {
+		return strings.EqualFold(strings.ReplaceAll(mapKey, "_", ""), strings.ReplaceAll(fieldName, "_", ""))
+	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"strings"
 	"syscall"
 
 	"github.com/projecteru2/core/log"
@@ -66,6 +67,7 @@ func newRootCmd() *cobra.Command {
 	_ = viper.BindPFlag("log.level", cmd.PersistentFlags().Lookup("log-level"))
 
 	viper.SetEnvPrefix("COCOON")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
 	viper.SetDefault("root_dir", "/var/lib/cocoon")
 	viper.SetDefault("run_dir", "/var/lib/cocoon/run")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	"github.com/spf13/viper"
-
-	"github.com/cocoonstack/cocoon/config"
 )
 
 func TestEnvOverridesDottedLogLevel(t *testing.T) {
@@ -21,16 +19,13 @@ func TestEnvOverridesDottedLogLevel(t *testing.T) {
 }
 
 func TestLogRotationKeysDecode(t *testing.T) {
-	v := viper.New()
-	v.SetDefault("log.max_size", 7)
-	v.SetDefault("log.max_age", 3)
-	v.SetDefault("log.max_backups", 2)
-
-	cfg := &config.Config{}
-	if err := v.Unmarshal(cfg, matchSnakeCase); err != nil {
-		t.Fatalf("unmarshal: %v", err)
+	t.Setenv("COCOON_LOG_MAXAGE", "7")
+	viper.Reset()
+	newRootCmd()
+	if err := initConfig(t.Context()); err != nil {
+		t.Fatalf("init config: %v", err)
 	}
-	if cfg.Log.MaxSize != 7 || cfg.Log.MaxAge != 3 || cfg.Log.MaxBackups != 2 {
-		t.Fatalf("log rotation: got %+v, want max_size=7 max_age=3 max_backups=2", cfg.Log)
+	if conf.Log.MaxSize != 500 || conf.Log.MaxAge != 7 || conf.Log.MaxBackups != 3 {
+		t.Fatalf("log rotation: got %+v, want maxsize=500 maxage=7 maxbackups=3", conf.Log)
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestEnvOverridesDottedLogLevel(t *testing.T) {
+	t.Setenv("COCOON_LOG_LEVEL", "debug")
+	viper.Reset()
+	newRootCmd()
+	if err := initConfig(t.Context()); err != nil {
+		t.Fatalf("init config: %v", err)
+	}
+	if conf.Log.Level != "debug" {
+		t.Fatalf("log level: got %q, want %q", conf.Log.Level, "debug")
+	}
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/spf13/viper"
+
+	"github.com/cocoonstack/cocoon/config"
 )
 
 func TestEnvOverridesDottedLogLevel(t *testing.T) {
@@ -15,5 +17,20 @@ func TestEnvOverridesDottedLogLevel(t *testing.T) {
 	}
 	if conf.Log.Level != "debug" {
 		t.Fatalf("log level: got %q, want %q", conf.Log.Level, "debug")
+	}
+}
+
+func TestLogRotationKeysDecode(t *testing.T) {
+	v := viper.New()
+	v.SetDefault("log.max_size", 7)
+	v.SetDefault("log.max_age", 3)
+	v.SetDefault("log.max_backups", 2)
+
+	cfg := &config.Config{}
+	if err := v.Unmarshal(cfg, matchSnakeCase); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cfg.Log.MaxSize != 7 || cfg.Log.MaxAge != 3 || cfg.Log.MaxBackups != 2 {
+		t.Fatalf("log rotation: got %+v, want max_size=7 max_age=3 max_backups=2", cfg.Log)
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	coretypes "github.com/projecteru2/core/types"
 	"github.com/spf13/viper"
 )
 
@@ -27,5 +30,27 @@ func TestLogRotationKeysDecode(t *testing.T) {
 	}
 	if conf.Log.MaxSize != 500 || conf.Log.MaxAge != 7 || conf.Log.MaxBackups != 3 {
 		t.Fatalf("log rotation: got %+v, want maxsize=500 maxage=7 maxbackups=3", conf.Log)
+	}
+}
+
+func TestConfigFileLogSection(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cocoon.yaml")
+	logPath := filepath.Join(dir, "cocoon.log")
+	body := "log:\n  level: warn\n  filename: " + logPath + "\n  maxsize: 7\n  maxage: 5\n  maxbackups: 1\n  usejson: true\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	viper.Reset()
+	newRootCmd()
+	cfgFile = path
+	t.Cleanup(func() { cfgFile = "" })
+
+	if err := initConfig(t.Context()); err != nil {
+		t.Fatalf("init config: %v", err)
+	}
+	want := coretypes.ServerLogConfig{Level: "warn", UseJSON: true, Filename: logPath, MaxSize: 7, MaxAge: 5, MaxBackups: 1}
+	if *conf.Log != want {
+		t.Fatalf("log config: got %+v, want %+v", *conf.Log, want)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/creack/pty v1.1.24
 	github.com/docker/go-units v0.5.0
 	github.com/fsnotify/fsnotify v1.9.0
+	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/gofrs/flock v0.13.0
 	github.com/google/go-containerregistry v0.21.7
 	github.com/google/uuid v1.6.0
@@ -34,7 +35,6 @@ require (
 	github.com/docker/docker-credential-helpers v0.9.8 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/getsentry/sentry-go v0.48.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/creack/pty v1.1.24
 	github.com/docker/go-units v0.5.0
 	github.com/fsnotify/fsnotify v1.9.0
-	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/gofrs/flock v0.13.0
 	github.com/google/go-containerregistry v0.21.7
 	github.com/google/uuid v1.6.0
@@ -35,6 +34,7 @@ require (
 	github.com/docker/docker-credential-helpers v0.9.8 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/getsentry/sentry-go v0.48.0 // indirect
+	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/images/gc.go
+++ b/images/gc.go
@@ -119,7 +119,7 @@ func BuildGCModule[E any](cfg GCModuleConfig[E]) gc.Module[ImageGCSnapshot] {
 					}
 				}
 				_ = fl.Close()
-				logger.Infof(ctx, "collected blob=%s", hex)
+				logger.Infof(ctx, "collected blob=%s reason=unreferenced", hex)
 			}
 			return errors.Join(errs...)
 		},

--- a/images/gc_test.go
+++ b/images/gc_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	gofrsflock "github.com/gofrs/flock"
+	"github.com/projecteru2/core/log"
+	coretypes "github.com/projecteru2/core/types"
 
 	metajson "github.com/cocoonstack/cocoon/meta/json"
 	"github.com/cocoonstack/cocoon/meta/tombstone"
@@ -194,6 +197,43 @@ func TestPinBlobs(t *testing.T) {
 
 	if _, err := PinBlobs(cfg, map[string]struct{}{"cafebabe": {}}); err == nil {
 		t.Fatal("pin of a missing blob must fail")
+	}
+}
+
+func TestGCCollectLogsUnreferencedReason(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "gc.log")
+	if err := log.SetupLog(ctx, &coretypes.ServerLogConfig{Level: "info", Filename: logPath}, ""); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = log.SetupLog(ctx, &coretypes.ServerLogConfig{Level: "info"}, "") })
+
+	engine, err := metajson.Open(metajson.Namespace{Name: "images_reason", FilePath: filepath.Join(dir, "images.json"), LockPath: filepath.Join(dir, "images.lock"), Codec: testImageTables})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = engine.Close() })
+
+	mod := BuildGCModule(GCModuleConfig[gcTestEntry]{
+		Name:     "oci",
+		Store:    NewMetaStore[gcTestEntry](engine, "images_reason"),
+		LockPath: func(hex string) string { return filepath.Join(dir, hex+".lock") },
+		ReadRefs: func(map[string]*gcTestEntry) map[string]struct{} { return map[string]struct{}{} },
+		ScanDisk: func() ([]string, error) { return []string{"deadbeef"}, nil },
+		Removers: []func(string) error{func(string) error { return nil }},
+		TempDir:  dir,
+	})
+	if err := mod.Collect(ctx, []string{"deadbeef"}, ImageGCSnapshot{}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), "collected blob=deadbeef reason=unreferenced") {
+		t.Fatalf("gc.oci log: got %s, want a collected line with reason=unreferenced", out)
 	}
 }
 


### PR DESCRIPTION
Three config/logging bugs surfaced by a docs-vs-code audit. Bugs 1 and 2 each have a regression test that fails on `master`; bug 3 has a log-capture test.

## 1. `COCOON_LOG_LEVEL` was never read

`cmd/root.go` binds `--log-level` to the viper key `log.level` and enables `AutomaticEnv` under the `COCOON` prefix, but registered no env key replacer. viper builds the env name from the raw key, so it looked for `COCOON_LOG.LEVEL` — not a legal shell identifier — and the `COCOON_LOG_LEVEL` documented in `docs/cli.md` silently did nothing.

`SetEnvKeyReplacer(strings.NewReplacer(".", "_"))` restores it. Every other documented `COCOON_*` key is flat, has no dot, and keeps the exact env name it had. A set `--log-level` flag still beats the env, verified separately.

## 2. Log rotation keys decoded to zero

`log` unmarshals into `*coretypes.ServerLogConfig`, whose fields carry only `yaml` tags. mapstructure resolves field names, not yaml tags, and its case-insensitive fallback cannot bridge `max_size` to `MaxSize`. So the registered `log.max_size`, `log.max_age` and `log.max_backups` defaults all decoded to zero, and a rotating file logger ran on lumberjack's implicit 100MB with unlimited retention instead of the intended 500 / 28 / 3.

Two commits here. The first tried a `MatchName` that folds underscores out of both sides; a review pass found that unsound and the second replaces it. Folding makes two source keys match one field — a config file's `log.maxsize` and the always-registered `log.max_size` default both resolve to `MaxSize` — and mapstructure breaks on the first match in randomized map order, so the value became a coin flip. Measured over 200 decodes of `log.maxsize: 7` against the `log.max_size: 500` default: 155 times 7, 45 times 500. On `master` that config decodes to 7 every time.

The kept fix registers the keys under the names `coretypes.ServerLogConfig` actually resolves — `log.maxsize`, `log.maxage`, `log.maxbackups`. No matcher, no `MatchName`, and `go.mod` is untouched. Every spelling that decoded on `master` decodes identically; the three broken key names are simply corrected. Verified deterministic at 300 decodes each for defaults only, `maxsize` set, the dead `max_size` set, and both present.

A fifth commit adds `TestConfigFileLogSection`, which writes a real YAML file and asserts the whole struct. The registered key names are coupled to a third-party struct's field names, so a `projecteru2/core` bump that renames a field should fail loudly rather than silently revert the section to defaults.

Three notes for the docs pass:

- The rotation settings only take effect when `log.filename` is set. `core/log` builds the lumberjack writer only for a non-empty `Filename`; the default is an unrotated stderr console writer.
- `metering.backend` and `metering.file.path` are documented as config-file-only. They stay unregistered with the env loader, but once a config file defines one, the replacer does make `COCOON_METERING_BACKEND` reach it.
- The accepted log keys are `level`, `filename`, `usejson`, `maxsize`, `maxage`, `maxbackups`, which is inconsistent with the snake_case used by every other cocoon key. That is inherited: `coretypes.ServerLogConfig`'s own yaml tags mix `maxsize` with `max_age`, and mapstructure matches field names rather than tags, so exactly one spelling per field can work. Giving cocoon its own snake_case log type with explicit `mapstructure` tags would fix it, but that changes `config.Config.Log`'s exported type and drops the compact spellings that work today. It is a schema decision, not a bug fix, so it is left as a follow-up rather than folded in here.

## 3. Image GC logged no `reason`

`docs/gc.md` documents `INFO gc.oci collected blob=... reason=unreferenced` and lists `unreferenced` for both the oci and cloudimg lanes. Every other GC module emits the field. The shared image-GC line did not, so operators filtering on `reason=` missed image collections entirely. Nothing else in the tree parses that line.

## Gates

`GOWORK=off` from the worktree root, re-run after the final commit:

| Gate | Result |
| --- | --- |
| `make lint` (GOOS=linux, GOOS=darwin) | `0 issues.` each |
| `make fmt-check` | exit 0 |
| `golangci-lint fmt --diff` (pinned v2.13.2) | empty, exit 0 |
| `asl ./...` (darwin + GOOS=linux) | exit 0, no findings |
| `go test -race -count=1 -timeout 15m ./...` | all 35 packages ok |

Comment lines added: 0.

One earlier full-suite run hit `utils.TestWatchFileDebounce`, a wall-clock debounce test with a 200ms window that this branch does not touch. It passes on rerun and the last three full passes are green.
