### PR TITLE
test: pin the log.maxsize decode against map-order flakiness

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	coretypes "github.com/projecteru2/core/types"
@@ -67,6 +68,11 @@ func TestLogMaxSizeDecodeIsStable(t *testing.T) {
 	viper.SetConfigFile(path)
 	if err := viper.ReadInConfig(); err != nil {
 		t.Fatalf("read config: %v", err)
+	}
+
+	keys := viper.AllKeys()
+	if !slices.Contains(keys, "log.maxsize") || slices.Contains(keys, "log.max_size") {
+		t.Fatalf("registered log keys: got %v, want log.maxsize present and log.max_size absent", keys)
 	}
 
 	for i := range 64 {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -7,6 +7,8 @@ import (
 
 	coretypes "github.com/projecteru2/core/types"
 	"github.com/spf13/viper"
+
+	"github.com/cocoonstack/cocoon/config"
 )
 
 func TestEnvOverridesDottedLogLevel(t *testing.T) {
@@ -52,5 +54,28 @@ func TestConfigFileLogSection(t *testing.T) {
 	want := coretypes.ServerLogConfig{Level: "warn", UseJSON: true, Filename: logPath, MaxSize: 7, MaxAge: 5, MaxBackups: 1}
 	if *conf.Log != want {
 		t.Fatalf("log config: got %+v, want %+v", *conf.Log, want)
+	}
+}
+
+func TestLogMaxSizeDecodeIsStable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cocoon.yaml")
+	if err := os.WriteFile(path, []byte("log:\n  maxsize: 7\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	viper.Reset()
+	newRootCmd()
+	viper.SetConfigFile(path)
+	if err := viper.ReadInConfig(); err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	for i := range 64 {
+		cfg := &config.Config{}
+		if err := viper.Unmarshal(cfg); err != nil {
+			t.Fatalf("unmarshal %d: %v", i, err)
+		}
+		if cfg.Log.MaxSize != 7 {
+			t.Fatalf("decode %d: maxsize got %d, want 7", i, cfg.Log.MaxSize)
+		}
 	}
 }


### PR DESCRIPTION
Follow-up to #212. That PR merged at head `7cfef95`; this test commit was written after and did not make it in.

#212 fixed the log rotation decode by registering the keys under the names `coretypes.ServerLogConfig` actually resolves, after an earlier attempt using a `MatchName` that folded underscores out of both sides was found unsound. Folding let two source keys match one field, and mapstructure takes the first hit in randomized map order, so `log.maxsize: 7` in a config file decoded to 7 or to the registered `log.max_size: 500` default at random.

Nothing in the tree guards against reintroducing that. The three existing log tests each decode once, so a folding matcher passes them roughly three times in four.

`TestLogMaxSizeDecodeIsStable` writes a config file with `log.maxsize: 7`, reads it through the real `newRootCmd` default set, and decodes 64 times, asserting 7 every time. Verified by reintroducing the rejected matcher and the old `log.max_size` default: it fails on the first or second decode.

Gates, `GOWORK=off` from the worktree root:

| Gate | Result |
| --- | --- |
| `make lint` (GOOS=linux, GOOS=darwin) | `0 issues.` each |
| `make fmt-check` | exit 0 |
| `asl ./...` (darwin + GOOS=linux) | exit 0, no findings |
| `go test -race -count=1 -timeout 15m ./...` | all 35 packages ok |

Comment lines added: 0. Test-only, no production change.
