### PR TITLE
doctor: install the cocoonstack fork builds of cloud-hypervisor and the firmware

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -6,12 +6,12 @@ Requirements, install paths, the doctor script, and a first VM.
 
 - Linux with KVM (x86_64 or aarch64)
 - Root access (sudo)
-- [Cloud Hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor) v53.0, what `cocoon-check --upgrade` installs (for Windows VMs and `--restore-mode mmap`, use our [CH fork](https://github.com/cocoonstack/cloud-hypervisor/tree/dev) and [firmware fork](https://github.com/cocoonstack/rust-hypervisor-firmware/tree/dev) for full compatibility — see [known issues](known-issues.md))
+- [Cloud Hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor) v54 or newer. `cocoon-check --upgrade` installs the [cocoonstack fork](https://github.com/cocoonstack/cloud-hypervisor/tree/dev) `dev` release build (upstream main plus diff snapshots and a QCOW cluster-leak fix), verified against the release checksums; v53.0 and older have no CopyOnWrite memory restore, so the default clone/restore mode (`mmap`) is rejected and `cocoon-check` reports it
 - [Firecracker](https://github.com/firecracker-microvm/firecracker) v1.16.1+ (optional, for `--fc` backend; `vm clone` needs >= v1.16 for the vsock override, and v1.16.0 permanently breaks guest vsock after any restore, so v1.16.1 is the effective floor — what `doctor/check.sh` installs; see [known issues](known-issues.md))
 - `qemu-img` (from qemu-utils, for cloud images)
 - `mkfs.erofs` from erofs-utils **>= 1.8** (for OCI images; 1.7.x tar mode
   silently corrupts layers — cocoon refuses to convert with older versions)
-- UEFI firmware (`CLOUDHV.fd`, for cloud images, not needed with `--fc`)
+- UEFI firmware (`CLOUDHV.fd`, for cloud images, not needed with `--fc`); on x86_64 `cocoon-check --upgrade` installs the [firmware fork](https://github.com/cocoonstack/rust-hypervisor-firmware/tree/dev) `dev` build (EFI ResetSystem for ACPI power-button shutdown and the IA32_FEATURE_CONTROL/VMXON lock, both needed by Windows guests — see [known issues](known-issues.md))
 - CNI plugins (`bridge`, `host-local`, `loopback`)
 - Go 1.27+ (build only)
 
@@ -65,10 +65,12 @@ cocoon-check --upgrade
 ```
 
 The `--upgrade` flag downloads and installs:
-- Cloud Hypervisor + ch-remote (static binaries)
+- Cloud Hypervisor from the cocoonstack fork `dev` release (checksum-verified) and upstream ch-remote (static binaries)
 - Firecracker (static binary)
-- CLOUDHV.fd firmware (rust-hypervisor-firmware)
+- CLOUDHV.fd firmware: the cocoonstack firmware fork `dev` build on x86_64 (checksum-verified), upstream rust-hypervisor-firmware on aarch64
 - CNI plugins (bridge, host-local, loopback, etc.)
+
+Release tags and versions are overridable through `CH_REF`, `CH_REMOTE_VERSION`, `FC_VERSION`, `FW_REF`, `FW_VERSION` and `CNI_VERSION` (see `cocoon-check --help`).
 
 ## Quick Start
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -17,9 +17,9 @@ The `--windows` flag:
 
 ### Requirements
 
-- Cloud Hypervisor **v53.0** (what `cocoon-check --upgrade` installs) with our [CH fork](https://github.com/cocoonstack/cloud-hypervisor/tree/dev) (includes DISCARD fix, virtio-net ctrl_queue fix, and upstream patches — see [known issues](known-issues.md))
-- UEFI firmware from our [firmware fork](https://github.com/cocoonstack/rust-hypervisor-firmware/tree/dev) (includes ResetSystem fix for ACPI power-button — see [known issues](known-issues.md))
-- virtio-win **0.1.285** drivers pre-installed in the image (0.1.240 also works for any version of Cloud Hypervisor; newer versions are supported with our CH fork)
+- Cloud Hypervisor **v54 or newer**: `cocoon-check --upgrade` installs the [cocoonstack fork](https://github.com/cocoonstack/cloud-hypervisor/tree/dev) `dev` release build. The Windows-relevant fixes (virtio-blk DISCARD, virtio-net ctrl_queue tolerance) are upstream since v51/v52; the fork only adds diff snapshots and a QCOW cluster-leak fix on top of upstream main — see [known issues](known-issues.md)
+- UEFI firmware from our [firmware fork](https://github.com/cocoonstack/rust-hypervisor-firmware/tree/dev) `dev` build, what `cocoon-check --upgrade` installs on x86_64 (EFI ResetSystem for the ACPI power-button and the IA32_FEATURE_CONTROL/VMXON lock — see [known issues](known-issues.md)); upstream 0.5.0 boots Windows but `cocoon vm stop` falls back to the 30s timeout
+- virtio-win **0.1.285** drivers pre-installed in the image (0.1.240 also works; newer versions need the ctrl_queue tolerance, i.e. Cloud Hypervisor v52 or newer)
 
 ### Image
 

--- a/doctor/check.sh
+++ b/doctor/check.sh
@@ -18,11 +18,18 @@ COCOON_CNI_CONF_DIR="${COCOON_CNI_CONF_DIR:-/etc/cni/net.d}"
 COCOON_CNI_BIN_DIR="${COCOON_CNI_BIN_DIR:-/opt/cni/bin}"
 COCOON_META_BACKEND="${COCOON_META_BACKEND:-}"
 
-# Dependency versions
-CH_VERSION="${CH_VERSION:-v53.0}"
+# Dependency versions. cloud-hypervisor and the x86_64 firmware come from the cocoonstack fork
+# release tags (rolling dev builds verified against their SHA256SUMS); ch-remote, Firecracker,
+# the aarch64 firmware and the CNI plugins come from upstream releases.
+CH_REF="${CH_REF:-dev}"
+CH_REMOTE_VERSION="${CH_REMOTE_VERSION:-v53.0}"
+CH_MIN_MAJOR=54
 FC_VERSION="${FC_VERSION:-v1.16.1}"
+FW_REF="${FW_REF:-dev}"
 FW_VERSION="${FW_VERSION:-0.5.0}"
 CNI_VERSION="${CNI_VERSION:-v1.9.1}"
+CH_RELEASE_BASE="https://github.com/cocoonstack/cloud-hypervisor/releases/download/${CH_REF}"
+FW_RELEASE_BASE="https://github.com/cocoonstack/rust-hypervisor-firmware/releases/download/${FW_REF}"
 
 # Architecture detection
 ARCH=$(uname -m)
@@ -53,15 +60,20 @@ Usage: $0 [--fix] [--upgrade] [--subnet=CIDR]
 Options:
   --fix            Attempt to fix detected issues (dirs, sysctl, iptables, CNI config)
   --upgrade        Fix issues and install/upgrade dependencies:
-                     cloud-hypervisor ${CH_VERSION}
-                     hypervisor-fw    ${FW_VERSION}
+                     cloud-hypervisor cocoonstack fork release ${CH_REF}
+                     ch-remote        ${CH_REMOTE_VERSION}
+                     firecracker      ${FC_VERSION}
+                     hypervisor-fw    cocoonstack fork release ${FW_REF} (x86_64), ${FW_VERSION} (aarch64)
                      CNI plugins      ${CNI_VERSION}
   --subnet=CIDR    Subnet for generated CNI bridge config (default: 10.88.0.0/16)
 
 Environment variables:
-  CH_VERSION    Cloud Hypervisor version    (default: ${CH_VERSION})
-  FW_VERSION    Firmware version            (default: ${FW_VERSION})
-  CNI_VERSION   CNI plugins version         (default: ${CNI_VERSION})
+  CH_REF            cocoonstack/cloud-hypervisor release tag   (default: ${CH_REF})
+  CH_REMOTE_VERSION upstream ch-remote version                 (default: ${CH_REMOTE_VERSION})
+  FC_VERSION        Firecracker version                        (default: ${FC_VERSION})
+  FW_REF            cocoonstack/rust-hypervisor-firmware tag   (default: ${FW_REF})
+  FW_VERSION        upstream firmware version, aarch64 only    (default: ${FW_VERSION})
+  CNI_VERSION       CNI plugins version                        (default: ${CNI_VERSION})
   COCOON_ROOT_DIR / COCOON_RUN_DIR / COCOON_LOG_DIR
   COCOON_CNI_CONF_DIR / COCOON_CNI_BIN_DIR
   COCOON_META_BACKEND Metadata engine       (default: auto — existing store wins, fresh roots get sqlite)
@@ -160,6 +172,26 @@ erofs_version_ok() {
     [ "$major" -gt 1 ] || { [ "$major" -eq 1 ] && [ "$minor" -ge 8 ]; }
 }
 
+# CopyOnWrite memory restore (cocoon --restore-mode mmap, the clone default) landed after v53.0.
+ch_version_ok() {
+    local major
+    major=$(echo "$1" | grep -oE 'v[0-9]+' | head -1 | tr -d v)
+    [ -n "$major" ] && [ "$major" -ge "$CH_MIN_MAJOR" ]
+}
+
+# verify_sha256 FILE SUMS NAME: NAME is matched as the trailing path component of a sha256sum line.
+verify_sha256() {
+    local file="$1" sums="$2" name="$3" want got
+    want=$(grep -E "(^|[[:space:]]|/)${name}\$" "$sums" | head -1 | awk '{print $1}')
+    got=$(sha256sum "$file" | awk '{print $1}')
+    [ -n "$want" ] && [ "$want" = "$got" ]
+}
+
+# release_commit BASE_URL: short commit of a cocoonstack fork release, from its build-info.json.
+release_commit() {
+    curl -fsSL "$1/build-info.json" 2>/dev/null | grep -oE '"commit": *"[0-9a-f]+"' | grep -oE '[0-9a-f]{40}' | cut -c1-8
+}
+
 check_binary() {
     local name="$1"
     if command -v "$name" &>/dev/null; then
@@ -175,6 +207,10 @@ check_binary() {
         esac
         if [ "$name" = "mkfs.erofs" ] && ! erofs_version_ok "$ver"; then
             fail "$name (${ver:-unknown}) is older than 1.8 — tar mode silently corrupts layers; apt ships 1.7.x, install erofs-utils >= 1.8 from source"
+            return
+        fi
+        if [ "$name" = "cloud-hypervisor" ] && ! ch_version_ok "$ver"; then
+            fail "$name (${ver:-unknown}) predates v${CH_MIN_MAJOR} — no CopyOnWrite memory restore, so the default clone/restore mode (mmap) is rejected; run --upgrade for the cocoonstack fork build"
             return
         fi
         pass "${name}${ver:+ ($ver)}"
@@ -494,29 +530,31 @@ if $UPGRADE; then
     trap 'rm -rf "$tmpdir"' EXIT
 
     # -- cloud-hypervisor --------------------------------------------------
-    header "Install cloud-hypervisor ${CH_VERSION}"
+    header "Install cloud-hypervisor (cocoonstack fork ${CH_REF})"
 
-    ch_url="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/${CH_VERSION}/cloud-hypervisor-static${CH_SUFFIX}"
+    ch_url="${CH_RELEASE_BASE}/cloud-hypervisor-${ARCH}"
     ch_dest="/usr/local/bin/cloud-hypervisor"
     info "downloading ${ch_url}"
-    if curl -fsSL -o "${tmpdir}/cloud-hypervisor" "$ch_url"; then
+    if curl -fsSL -o "${tmpdir}/cloud-hypervisor" "$ch_url" \
+        && curl -fsSL -o "${tmpdir}/ch.sums" "${CH_RELEASE_BASE}/SHA256SUMS" \
+        && verify_sha256 "${tmpdir}/cloud-hypervisor" "${tmpdir}/ch.sums" "cloud-hypervisor-${ARCH}"; then
         install -m 0755 "${tmpdir}/cloud-hypervisor" "$ch_dest"
         # virtio-net requires CAP_NET_ADMIN for tap devices
         setcap cap_net_admin+ep "$ch_dest" 2>/dev/null || true
-        fixed "cloud-hypervisor ${CH_VERSION} -> ${ch_dest}"
+        fixed "cloud-hypervisor ${CH_REF} (commit $(release_commit "$CH_RELEASE_BASE")) -> ${ch_dest}"
     else
-        fail "failed to download cloud-hypervisor from ${ch_url}"
+        fail "failed to download or verify cloud-hypervisor from ${ch_url}"
     fi
 
     # -- ch-remote ----------------------------------------------------------
-    header "Install ch-remote ${CH_VERSION}"
+    header "Install ch-remote ${CH_REMOTE_VERSION}"
 
-    chr_url="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/${CH_VERSION}/ch-remote-static${CH_SUFFIX}"
+    chr_url="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/${CH_REMOTE_VERSION}/ch-remote-static${CH_SUFFIX}"
     chr_dest="/usr/local/bin/ch-remote"
     info "downloading ${chr_url}"
     if curl -fsSL -o "${tmpdir}/ch-remote" "$chr_url"; then
         install -m 0755 "${tmpdir}/ch-remote" "$chr_dest"
-        fixed "ch-remote ${CH_VERSION} -> ${chr_dest}"
+        fixed "ch-remote ${CH_REMOTE_VERSION} -> ${chr_dest}"
     else
         fail "failed to download ch-remote from ${chr_url}"
     fi
@@ -538,15 +576,31 @@ if $UPGRADE; then
     fi
 
     # -- firmware -----------------------------------------------------------
-    header "Install hypervisor-fw ${FW_VERSION}"
-
-    fw_url="https://github.com/cloud-hypervisor/rust-hypervisor-firmware/releases/download/${FW_VERSION}/hypervisor-fw${FW_SUFFIX}"
     mkdir -p "$FIRMWARE_DIR"
-    info "downloading ${fw_url}"
-    if curl -fsSL -o "${FIRMWARE_PATH}" "$fw_url"; then
-        fixed "hypervisor-fw ${FW_VERSION} -> ${FIRMWARE_PATH}"
+    if [ "$ARCH" = "x86_64" ]; then
+        header "Install hypervisor-fw (cocoonstack fork ${FW_REF})"
+
+        fw_url="${FW_RELEASE_BASE}/hypervisor-fw"
+        info "downloading ${fw_url}"
+        if curl -fsSL -o "${tmpdir}/hypervisor-fw" "$fw_url" \
+            && curl -fsSL -o "${tmpdir}/fw.sums" "${fw_url}.sha256" \
+            && verify_sha256 "${tmpdir}/hypervisor-fw" "${tmpdir}/fw.sums" "hypervisor-fw"; then
+            install -m 0644 "${tmpdir}/hypervisor-fw" "${FIRMWARE_PATH}"
+            fixed "hypervisor-fw ${FW_REF} (commit $(release_commit "$FW_RELEASE_BASE")) -> ${FIRMWARE_PATH}"
+        else
+            fail "failed to download or verify firmware from ${fw_url}"
+        fi
     else
-        fail "failed to download firmware from ${fw_url}"
+        header "Install hypervisor-fw ${FW_VERSION}"
+
+        fw_url="https://github.com/cloud-hypervisor/rust-hypervisor-firmware/releases/download/${FW_VERSION}/hypervisor-fw${FW_SUFFIX}"
+        info "downloading ${fw_url}"
+        if curl -fsSL -o "${tmpdir}/hypervisor-fw" "$fw_url"; then
+            install -m 0644 "${tmpdir}/hypervisor-fw" "${FIRMWARE_PATH}"
+            fixed "hypervisor-fw ${FW_VERSION} -> ${FIRMWARE_PATH}"
+        else
+            fail "failed to download firmware from ${fw_url}"
+        fi
     fi
 
     # -- zstd (for FC kernel decompression) -----------------------------------


### PR DESCRIPTION
## Why

`cocoon-check --upgrade` installed upstream Cloud Hypervisor v53.0, which has no CopyOnWrite memory restore. cocoon's default clone/restore mode is `mmap`, which maps to exactly that mode, so a doctor-provisioned host rejects every default clone with a 400 from `vm.restore`. The cocoonstack fork `dev` release build (upstream main plus diff snapshots and the QCOW cluster-leak fix, `cloud-hypervisor v54.0.0`) has it. The firmware fork carries the EFI ResetSystem and IA32_FEATURE_CONTROL/VMXON-lock fixes that Windows guests need, and the docs already told people to use both forks by hand.

## What

- `doctor/check.sh --upgrade` installs `cloud-hypervisor-<arch>` from the `cocoonstack/cloud-hypervisor` release tag `CH_REF` (default `dev`) and, on x86_64, `hypervisor-fw` from the `cocoonstack/rust-hypervisor-firmware` tag `FW_REF` (default `dev`). Both downloads are verified against the published `SHA256SUMS` / `.sha256` before `install`, and the `FIXED` line records the build commit from the release's `build-info.json`.
- ch-remote (`CH_REMOTE_VERSION`, v53.0 — the fork release ships no ch-remote asset), Firecracker (`FC_VERSION`, v1.16.1), the aarch64 firmware (`FW_VERSION`, 0.5.0 — the fork publishes x86_64 only) and the CNI plugins stay on upstream releases.
- The check pass fails a `cloud-hypervisor` older than v54 with the reason (no CopyOnWrite restore, default mode rejected) instead of passing a host that cannot clone.
- `docs/install.md` and `docs/windows.md` state what the forks actually carry today. The DISCARD and virtio-net ctrl_queue fixes the Windows page attributed to the fork are upstream (v51.0 / v52.0); the fork's own delta is diff snapshots and the QCOW fix.

No cocoon code change: a CH that rejects `CopyOnWrite` already fails loud (`PUT vm.restore → 400: <CH body>` through `utils.DoAPI`), and a silent fallback to `copy` would be the ~6x restore-latency regression the restore code refuses by design.

## Evidence

- `bash -n doctor/check.sh` clean; `shellcheck -S warning` reports only the pre-existing SC2034 (`prefix_len`, untouched).
- `--upgrade` run in `debian:bookworm-slim` containers on both architectures (`COCOON_*_DIR` under `/tmp`, curl + libcap2-bin only):

```
# linux/arm64 (native)
==> Install cloud-hypervisor (cocoonstack fork dev)
  [FIXED] cloud-hypervisor dev (commit 815f40b5) -> /usr/local/bin/cloud-hypervisor
==> Install ch-remote v53.0 … [FIXED]
==> Install firecracker v1.16.1 … [FIXED]
==> Install hypervisor-fw 0.5.0
  [FIXED] hypervisor-fw 0.5.0 -> /tmp/cocoon/firmware/CLOUDHV.fd
==> Install CNI plugins v1.9.1 … [FIXED]
20fa683ac2626b97efabdbaae300b5119699aaf9f558c81108c8bce7bbda5e2c  /usr/local/bin/cloud-hypervisor   (= SHA256SUMS cloud-hypervisor-aarch64)

# linux/amd64 (emulated)
==> Install cloud-hypervisor (cocoonstack fork dev)
  [FIXED] cloud-hypervisor dev (commit 815f40b5) -> /usr/local/bin/cloud-hypervisor
==> Install hypervisor-fw (cocoonstack fork dev)
  [FIXED] hypervisor-fw dev (commit 4161be33) -> /tmp/cocoon/firmware/CLOUDHV.fd
0bd06a827ee943185c11142f04406380d8240f6ae3668e49aa4089cca9055064  /usr/local/bin/cloud-hypervisor   (= SHA256SUMS cloud-hypervisor-x86_64)
b53d0a7492ac4cdbac1c5d6a05acd53e8d96e71b955720a20171b026383fce9c  /tmp/cocoon/firmware/CLOUDHV.fd   (= hypervisor-fw.sha256)
```

- The same fork builds (`cloud-hypervisor v54.0.0` 815f40b) drove cocoon master on the bare-metal testbed today: `vm run`, `vm net --nics 2`, `vm disk attach/detach`, stop and rm all clean (cocoon-specs `tests/2026-09-05-fc-hotplug-mtu-parity.md`).
