### PR TITLE
review: cmp.Or for zero-value fallbacks

### DIFF
--- a/hypervisor/cgroup_linux.go
+++ b/hypervisor/cgroup_linux.go
@@ -1,6 +1,7 @@
 package hypervisor
 
 import (
+	"cmp"
 	"os"
 	"os/exec"
 	"syscall"
@@ -8,9 +9,7 @@ import (
 
 // setCmdCgroupFD lands cmd's clone3 directly in the scope (CLONE_INTO_CGROUP), so there is no post-fork attach race.
 func setCmdCgroupFD(cmd *exec.Cmd, scope *os.File) {
-	if cmd.SysProcAttr == nil {
-		cmd.SysProcAttr = &syscall.SysProcAttr{}
-	}
+	cmd.SysProcAttr = cmp.Or(cmd.SysProcAttr, &syscall.SysProcAttr{})
 	cmd.SysProcAttr.UseCgroupFD = true
 	cmd.SysProcAttr.CgroupFD = int(scope.Fd())
 }

--- a/types/vm.go
+++ b/types/vm.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"cmp"
 	"fmt"
 	"regexp"
 	"time"
@@ -148,10 +149,7 @@ func (v *VM) ResolvedNetBackend() string {
 		return v.NetBackend
 	}
 	if nic := v.firstNIC(); nic != nil {
-		if nic.Backend != "" {
-			return nic.Backend
-		}
-		return BackendCNI
+		return cmp.Or(nic.Backend, BackendCNI)
 	}
 	return ""
 }


### PR DESCRIPTION
## Why

First gate run of the new asl analyzers: `cmpor` rewrites `if x != zero { return x }; return y` and `if x == zero { x = y }` into `cmp.Or(x, y)` where the fallback is call-free and already has x's type (cmp.Or evaluates every argument and infers one T).

## What

2 cmp.Or rewrites (`types/vm.go` ResolvedNetBackend, `hypervisor/cgroup_linux.go` setCmdCgroupFD), applied by `asl -fix` and `goimports`; no behaviour change. The two `metering.NopRecorder{}` fallbacks stay as ifs: the operand is an interface, so cmp.Or would need an explicit instantiation.

## Evidence

`make fmt-check` clean; `make lint` 0 issues on linux and darwin; `asl` clean on both GOOS; `go test -race -count=1 ./...` 35 ok packages, no FAIL lines (one earlier run tripped the timing-sensitive `TestWatchFileDebounce` under load; it passes alone and in the full rerun).