### PR TITLE
cut: fold the Resolved* chains and give the clone record and COW lookup one owner

### DIFF
--- a/hypervisor/clone.go
+++ b/hypervisor/clone.go
@@ -45,6 +45,17 @@ func (b *Backend) CloneFromStream(ctx context.Context, vmID string, spec CloneSp
 	})
 }
 
+func (b *Backend) RunningCloneRecord(vmID string, vmCfg *types.VMConfig, storageConfigs []*types.StorageConfig, net types.NetSetup, runDir string, now time.Time) *types.VM {
+	info := &types.VM{
+		ID: vmID, Hypervisor: b.Typ, State: types.VMStateRunning,
+		Config: *vmCfg, StorageConfigs: storageConfigs,
+		NetSetup:  net,
+		CreatedAt: now, UpdatedAt: now, StartedAt: &now,
+	}
+	SetRunningSockets(info, runDir)
+	return info
+}
+
 // FinalizeClone persists the record and emits the clone open-interval pair.
 func (b *Backend) FinalizeClone(ctx context.Context, vmID string, info *types.VM, bootCfg *types.BootConfig, blobIDs map[string]struct{}, sourceSnapshotID string) error {
 	if err := b.UpdateRecord(ctx, vmID, func(r *VMRecord) error {

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -149,13 +149,7 @@ func (ch *CloudHypervisor) cloneAfterExtractParsed(ctx context.Context, vmID str
 	}
 	saveConsolePTY(ctx, vmID, runDir, sockPath, directBoot)
 
-	info := &types.VM{
-		ID: vmID, Hypervisor: typ, State: types.VMStateRunning,
-		Config: *vmCfg, StorageConfigs: storageConfigs,
-		NetSetup:  net,
-		CreatedAt: now, UpdatedAt: now, StartedAt: &now,
-	}
-	hypervisor.SetRunningSockets(info, runDir)
+	info := ch.RunningCloneRecord(vmID, vmCfg, storageConfigs, net, runDir, now)
 	if err := ch.FinalizeClone(ctx, vmID, info, bootCfg, nil, sourceSnapshotID); err != nil {
 		ch.AbortLaunch(ctx, pid, sockPath, runDir, runtimeFiles)
 		return nil, fmt.Errorf("finalize VM record: %w", err)

--- a/hypervisor/cloudhypervisor/snapshot.go
+++ b/hypervisor/cloudhypervisor/snapshot.go
@@ -34,10 +34,9 @@ func (ch *CloudHypervisor) snapshotSpec(ctx context.Context) hypervisor.Snapshot
 			if err := snapshotVM(ctx, hc, tmpDir); err != nil {
 				return fmt.Errorf("snapshot: %w", err)
 			}
-			// Recorded path, not conf-derived: after a --run-dir change the disks stay where the record says.
-			cowPath := hypervisor.DiskPathByRole(rec.StorageConfigs, types.StorageRoleCOW)
-			if cowPath == "" {
-				return fmt.Errorf("no COW disk recorded for %s", rec.ID)
+			cowPath, err := hypervisor.RecordedCOWPath(rec)
+			if err != nil {
+				return err
 			}
 			return hypervisor.CopyWritableDisks(ctx, tmpDir, cowPath, rec.StorageConfigs)
 		},

--- a/hypervisor/disks.go
+++ b/hypervisor/disks.go
@@ -46,6 +46,15 @@ func DiskPathByRole(configs []*types.StorageConfig, role types.StorageRole) stri
 	return ""
 }
 
+// RecordedCOWPath reads the recorded path, not a conf-derived one: after a --run-dir change the disks stay where the record says.
+func RecordedCOWPath(rec *VMRecord) (string, error) {
+	cowPath := DiskPathByRole(rec.StorageConfigs, types.StorageRoleCOW)
+	if cowPath == "" {
+		return "", fmt.Errorf("no COW disk recorded for %s", rec.ID)
+	}
+	return cowPath, nil
+}
+
 // CopyWritableDisks copies concurrently so pause-window wall time is the longest single copy, not the sum; durability is paid at persist.
 func CopyWritableDisks(ctx context.Context, dstDir, cowPath string, configs []*types.StorageConfig) error {
 	pairs := [][2]string{{filepath.Join(dstDir, filepath.Base(cowPath)), cowPath}}

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -130,13 +130,7 @@ func (fc *Firecracker) cloneAfterExtract(ctx context.Context, vmID string, vmCfg
 		return nil, fmt.Errorf("validate storage configs: %w", err)
 	}
 
-	info := &types.VM{
-		ID: vmID, Hypervisor: typ, State: types.VMStateRunning,
-		Config: *vmCfg, StorageConfigs: storageConfigs,
-		NetSetup:  net,
-		CreatedAt: now, UpdatedAt: now, StartedAt: &now,
-	}
-	hypervisor.SetRunningSockets(info, runDir)
+	info := fc.RunningCloneRecord(vmID, vmCfg, storageConfigs, net, runDir, now)
 	if err := fc.FinalizeClone(ctx, vmID, info, bootCfg, blobIDs, sourceSnapshotID); err != nil {
 		leaseControl.close()
 		fc.AbortLaunch(ctx, pid, sockPath, runDir, runtimeFiles)

--- a/hypervisor/firecracker/restore.go
+++ b/hypervisor/firecracker/restore.go
@@ -29,7 +29,7 @@ func (fc *Firecracker) Restore(ctx context.Context, vmRef string, vmCfg *types.V
 }
 
 func (fc *Firecracker) restoreAfterExtractCOW(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *hypervisor.VMRecord) (*types.VM, error) {
-	cowPath, err := recordedCOWPath(rec)
+	cowPath, err := hypervisor.RecordedCOWPath(rec)
 	if err != nil {
 		return nil, err
 	}

--- a/hypervisor/firecracker/snapshot.go
+++ b/hypervisor/firecracker/snapshot.go
@@ -46,7 +46,7 @@ func (fc *Firecracker) snapshotSpec(ctx context.Context) hypervisor.SnapshotSpec
 			if err := createSnapshotFC(ctx, sockPath, tmpDir); err != nil {
 				return fmt.Errorf("snapshot: %w", err)
 			}
-			cowPath, err := recordedCOWPath(rec)
+			cowPath, err := hypervisor.RecordedCOWPath(rec)
 			if err != nil {
 				return err
 			}

--- a/hypervisor/firecracker/utils.go
+++ b/hypervisor/firecracker/utils.go
@@ -34,11 +34,3 @@ func snapshotIntegrity(srcDir string, sidecar []*types.StorageConfig) error {
 	}
 	return nil
 }
-
-func recordedCOWPath(rec *hypervisor.VMRecord) (string, error) {
-	cowPath := hypervisor.DiskPathByRole(rec.StorageConfigs, types.StorageRoleCOW)
-	if cowPath == "" {
-		return "", fmt.Errorf("no COW disk recorded for %s", rec.ID)
-	}
-	return cowPath, nil
-}

--- a/types/vm.go
+++ b/types/vm.go
@@ -130,13 +130,10 @@ func (v *VM) ResolvedNetnsPath() string {
 	if v == nil {
 		return ""
 	}
-	if v.NetnsPath != "" {
-		return v.NetnsPath
-	}
 	if nic := v.firstNIC(); nic != nil {
-		return nic.NetnsPath
+		return cmp.Or(v.NetnsPath, nic.NetnsPath)
 	}
-	return ""
+	return v.NetnsPath
 }
 
 // ResolvedNetBackend returns NetBackend, with NIC[0] fallback.
@@ -144,13 +141,10 @@ func (v *VM) ResolvedNetBackend() string {
 	if v == nil {
 		return ""
 	}
-	if v.NetBackend != "" {
-		return v.NetBackend
-	}
 	if nic := v.firstNIC(); nic != nil {
-		return cmp.Or(nic.Backend, BackendCNI)
+		return cmp.Or(v.NetBackend, nic.Backend, BackendCNI)
 	}
-	return ""
+	return v.NetBackend
 }
 
 // ResolvedNetBridgeDev returns NetBridgeDev, with NIC[0] fallback.
@@ -158,13 +152,10 @@ func (v *VM) ResolvedNetBridgeDev() string {
 	if v == nil {
 		return ""
 	}
-	if v.NetBridgeDev != "" {
-		return v.NetBridgeDev
-	}
 	if nic := v.firstNIC(); nic != nil {
-		return nic.BridgeDev
+		return cmp.Or(v.NetBridgeDev, nic.BridgeDev)
 	}
-	return ""
+	return v.NetBridgeDev
 }
 
 func (v *VM) firstNIC() *NetworkConfig {


### PR DESCRIPTION
Applies the cut-list from the whole-repo loc-justify at `b374c300` (base `f93dfb63`, 48 commits). Three commits, each its own item, no behavior change.

**Net: −10 prod lines** (9 files, +33/−43). Two of the three buy a single owner rather than volume — reported with their real numbers below rather than the pre-scan estimates.

1. **`types/vm.go` Resolved\* → `cmp.Or`** (−9). `ResolvedNetnsPath`, `ResolvedNetBackend` and `ResolvedNetBridgeDev` each hand-wrote the first-non-empty chain over the same two fields, and `ResolvedNetBackend` already used `cmp.Or` for its inner half. Equivalence checked over all four input combinations per method (direct value set/empty × NIC present/absent), including that the `BackendCNI` default still applies only when a NIC exists.
2. **`Backend.RunningCloneRecord`** (−1). Both backends built the same nine-field `types.VM` literal and called `SetRunningSockets` on it — `Hypervisor: typ` has exactly two occurrences in the tree, these two. `CreateSequence` already owns the create path's equivalent literal in the shared package; clone never got the same treatment because `AfterExtractFn` hands the whole post-launch job to the backend.
3. **`hypervisor.RecordedCOWPath`** (net 0). The `DiskPathByRole`-then-refuse block with a byte-identical `"no COW disk recorded for %s"` stood in three places: firecracker's package-local helper with two call sites, plus cloudhypervisor's capture hook inline. The record-not-conf-derived rationale moves from the CH call site to the shared godoc, so the comment count does not rise.

## Considered and rejected in the same round

So the next reader does not re-derive them:

- A shared helper for the CH/FC `restoreAfterExtract` post-launch tail (−8 to −12 on paper): it needs three callbacks to save eight lines, and the genuinely shared parts — `FinalizeRestore`, `AbortLaunch`, `ArmCPUQuota` — already live on `Backend`. Same shape as the tombstone-glue wrapper rejected in an earlier round.
- The three single-implementation snapshot capability interfaces (`NameHolder`, `CompressedExporter`, `DirectoryExporter`, ≈−30): staged for the remote/cross-node snapshot backend on the roadmap, and `DirectCreator` is a live test seam. Revisit only if no second backend lands.
- `cloudhypervisor/restore.go`'s disk-count guard (−4): redundant with `ValidateRoleSequence` in the preflight, but it is what turns a slice-range panic into an error at the slice boundary.
- `cgroup.Prepare`'s empty-vmID guard (−3): unreachable from its one caller, kept as an exported-API boundary.
- `runtimeFileToCLIArg`'s `case "file"` (−2): below the three-line fold threshold and mirrors Cloud Hypervisor's documented mode set.

Dead code came back clean: `deadcode -test ./...` (RTA, both GOOS, rebuilt under the 1.27 toolchain) reports zero in-repo unreachable functions, and `unused` is silent.

## Gates

Left to CI by request. Locally only `go build ./...` on both GOOS plus gofumpt/goimports on the touched files; the test suite and lint were not run here.
