### PR TITLE
review: judge round over the files #221 and #222 touched

### DIFF
--- a/cmd/images/manage.go
+++ b/cmd/images/manage.go
@@ -37,10 +37,7 @@ func (h Handler) List(cmd *cobra.Command, _ []string) error {
 	return cliutil.OutputFormatted(cmd, all, func(w *tabwriter.Writer) {
 		fmt.Fprintln(w, "TYPE\tNAME\tDIGEST\tSIZE\tCREATED") //nolint:errcheck
 		for _, img := range all {
-			digest := img.ID
-			if len(digest) > digestDisplayLen {
-				digest = digest[:digestDisplayLen]
-			}
+			digest := img.ID[:min(len(img.ID), digestDisplayLen)]
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", //nolint:errcheck
 				img.Type, img.Name, digest,
 				cliutil.FormatSize(img.Size),

--- a/cmd/others/handler.go
+++ b/cmd/others/handler.go
@@ -54,9 +54,6 @@ func parseSnapshotPolicy(cmd *cobra.Command) (localfile.EvictionPolicy, error) {
 		if err != nil {
 			return localfile.EvictionPolicy{}, fmt.Errorf("--snapshot-size %q: %w", sizeStr, err)
 		}
-		if n < 0 {
-			return localfile.EvictionPolicy{}, fmt.Errorf("--snapshot-size must be >= 0, got %s", sizeStr)
-		}
 		size = n
 	}
 

--- a/gc/module.go
+++ b/gc/module.go
@@ -36,17 +36,9 @@ func (m Module[S]) readSnapshot(ctx context.Context) (any, error) {
 }
 
 func (m Module[S]) resolveTargets(ctx context.Context, snap any, others map[string]any) []string {
-	typed, ok := snap.(S)
-	if !ok {
-		return nil
-	}
-	return m.Resolve(ctx, typed, others)
+	return m.Resolve(ctx, snap.(S), others)
 }
 
 func (m Module[S]) collect(ctx context.Context, ids []string, snap any) error {
-	typed, ok := snap.(S)
-	if !ok {
-		return nil
-	}
-	return m.Collect(ctx, ids, typed)
+	return m.Collect(ctx, ids, snap.(S))
 }

--- a/gc/orchestrator.go
+++ b/gc/orchestrator.go
@@ -41,18 +41,12 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		snapshots[m.getName()] = snap
 	}
 
-	targets := make(map[string][]string)
-	for _, m := range o.modules {
-		if ids := m.resolveTargets(ctx, snapshots[m.getName()], snapshots); len(ids) > 0 {
-			targets[m.getName()] = ids
-		}
-	}
-
 	summary := make(map[string]int, len(o.modules))
 	for _, m := range o.modules {
-		ids := targets[m.getName()]
+		snap := snapshots[m.getName()]
+		ids := m.resolveTargets(ctx, snap, snapshots)
 		// Collect runs even with no ids: modules sweep stale temp/capture leftovers there.
-		if err := m.collect(ctx, ids, snapshots[m.getName()]); err != nil {
+		if err := m.collect(ctx, ids, snap); err != nil {
 			errs = append(errs, fmt.Errorf("gc %s: %w", m.getName(), err))
 		}
 		if len(ids) > 0 {

--- a/hypervisor/backend.go
+++ b/hypervisor/backend.go
@@ -63,6 +63,7 @@ type BackendConfig interface {
 	CgroupCPUFence() string
 }
 
+// LaunchSpec is the per-call input to Backend.LaunchVMProcess; PID-file and socket paths derive from Rec.RunDir.
 type LaunchSpec struct {
 	Cmd       *exec.Cmd
 	NetnsPath string
@@ -186,5 +187,3 @@ func NewBackend(typ string, conf BackendConfig, rec metering.Recorder, store met
 }
 
 func (b *Backend) Type() string { return b.Typ }
-
-// LaunchSpec is the per-call input to Backend.LaunchVMProcess; PID-file and socket paths derive from Rec.RunDir.

--- a/hypervisor/baseconfig.go
+++ b/hypervisor/baseconfig.go
@@ -14,15 +14,21 @@ const (
 	defaultTerminateGracePeriod = 5 * time.Second
 )
 
-// BaseConfig holds the directory layout and timeout defaults shared by all hypervisor backends.
+// BaseConfig holds the directory layout, binary and timeout defaults shared by all hypervisor backends.
 type BaseConfig struct {
 	*config.Config
 	backendName string
+	binary      string
+	pidFile     string
 }
 
-func NewBaseConfig(conf *config.Config, name string) BaseConfig {
-	return BaseConfig{Config: conf, backendName: name}
+func NewBaseConfig(conf *config.Config, name, binary, pidFile string) BaseConfig {
+	return BaseConfig{Config: conf, backendName: name, binary: binary, pidFile: pidFile}
 }
+
+func (c *BaseConfig) BinaryName() string { return filepath.Base(c.binary) }
+
+func (c *BaseConfig) PIDFileName() string { return c.pidFile }
 
 func (c *BaseConfig) RunDir() string { return filepath.Join(c.Config.RunDir, c.backendName) }
 

--- a/hypervisor/baseconfig_test.go
+++ b/hypervisor/baseconfig_test.go
@@ -32,7 +32,7 @@ func TestResolveExternalVolume(t *testing.T) {
 		t.Fatalf("symlink: %v", err)
 	}
 
-	conf := NewBaseConfig(&config.Config{RootDir: rootDir, RunDir: runDir, LogDir: logDir}, "cloudhypervisor")
+	conf := NewBaseConfig(&config.Config{RootDir: rootDir, RunDir: runDir, LogDir: logDir}, "cloudhypervisor", "cloud-hypervisor", "ch.pid")
 
 	wantOK, err := filepath.EvalSymlinks(okVol)
 	if err != nil {

--- a/hypervisor/cloudhypervisor/config.go
+++ b/hypervisor/cloudhypervisor/config.go
@@ -14,12 +14,8 @@ type Config struct {
 
 // NewConfig creates a Config from a global config.
 func NewConfig(conf *config.Config) *Config {
-	return &Config{BaseConfig: hypervisor.NewBaseConfig(conf, "cloudhypervisor")}
+	return &Config{BaseConfig: hypervisor.NewBaseConfig(conf, "cloudhypervisor", conf.CHBinary, pidFileName)}
 }
-
-func (c *Config) BinaryName() string { return filepath.Base(c.CHBinary) }
-
-func (c *Config) PIDFileName() string { return pidFileName }
 
 func (c *Config) OverlayPath(vmID string) string {
 	return filepath.Join(c.VMRunDir(vmID), "overlay.qcow2")

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -42,7 +42,7 @@ func (p *bindRedirectPlan) files() []*os.File {
 
 func (p *bindRedirectPlan) close() { closeLeases(p.leases) }
 
-// recordExistsFn tells a live source VM from a dead one.
+// recordExistsFn reports whether the source VM's record survives; absent means the drive can be replaced with a placeholder.
 type recordExistsFn func(string) (bool, error)
 
 // launchCloneFn starts the FC process over the plan's redirected drive FDs.

--- a/hypervisor/firecracker/config.go
+++ b/hypervisor/firecracker/config.go
@@ -1,8 +1,6 @@
 package firecracker
 
 import (
-	"path/filepath"
-
 	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/hypervisor"
 )
@@ -14,9 +12,5 @@ type Config struct {
 
 // NewConfig creates a Config from a global config.
 func NewConfig(conf *config.Config) *Config {
-	return &Config{BaseConfig: hypervisor.NewBaseConfig(conf, "firecracker")}
+	return &Config{BaseConfig: hypervisor.NewBaseConfig(conf, "firecracker", conf.FCBinary, pidFileName)}
 }
-
-func (c *Config) BinaryName() string { return filepath.Base(c.FCBinary) }
-
-func (c *Config) PIDFileName() string { return pidFileName }

--- a/hypervisor/gc.go
+++ b/hypervisor/gc.go
@@ -134,7 +134,7 @@ func (b *Backend) gcRecover(ctx context.Context) []error {
 	var errs []error
 	for _, id := range ids {
 		b.withOpsTryLock(ctx, id, func() {
-			if _, err := b.recoverVMTombstone(ctx, id); err != nil {
+			if _, err := b.RecoverTombstone(ctx, id); err != nil {
 				errs = append(errs, fmt.Errorf("recover %s: %w", id, err))
 			}
 		})

--- a/hypervisor/supervisor.go
+++ b/hypervisor/supervisor.go
@@ -158,11 +158,6 @@ func (b *Backend) ReconcileStaleCreate(ctx context.Context, id string) (StaleCre
 	return StaleCreateCollected, nil
 }
 
-// RecoverTombstone drives an unfinished delete to completion under the held ops lock; supervision starts deletes of its own, so it must be able to finish them.
-func (b *Backend) RecoverTombstone(ctx context.Context, id string) (bool, error) {
-	return b.recoverVMTombstone(ctx, id)
-}
-
 func (b *Backend) observe(ctx context.Context, rec *VMRecord, scan *utils.ProcScan) (utils.ProcRef, error) {
 	var ref utils.ProcRef
 	err := b.withRunningVM(ctx, rec, scan, func(pid int) error {

--- a/hypervisor/teardown.go
+++ b/hypervisor/teardown.go
@@ -30,6 +30,31 @@ func (b *Backend) EntryGuardLoad(ctx context.Context, id string) (VMRecord, erro
 	return *rec, nil
 }
 
+// RecoverTombstone drives id's tombstone to completion under the held ops lock; supervision starts deletes of its own, so it must be able to finish them.
+func (b *Backend) RecoverTombstone(ctx context.Context, id string) (done bool, err error) { //nolint:unparam // done is asserted by the protocol gates
+	ts := b.tombstones()
+	var (
+		rec     *tombstone.Record
+		leaseID string
+		cl      vmCleanup
+	)
+	if err := b.update(ctx, func(t *vmTx) error {
+		var err error
+		rec, leaseID, err = ts.Recover(ctx, t.w, id, &cl)
+		return err
+	}); err != nil {
+		return false, err
+	}
+	if rec == nil {
+		return false, nil
+	}
+	if err := b.finishVMTeardown(ctx, id, leaseID, cl); err != nil {
+		return false, err
+	}
+	log.WithFunc(b.Typ+".RecoverTombstone").Warnf(ctx, "rolled forward interrupted delete of VM %s", id)
+	return true, nil
+}
+
 func (b *Backend) tombstones() *tombstone.Table {
 	return tombstone.NewTable(b.NS)
 }
@@ -96,31 +121,6 @@ func (b *Backend) finishVMTeardown(ctx context.Context, id, leaseID string, cl v
 	return err
 }
 
-// recoverVMTombstone drives id's tombstone to completion under the held ops lock.
-func (b *Backend) recoverVMTombstone(ctx context.Context, id string) (done bool, err error) { //nolint:unparam // done is asserted by the protocol gates
-	ts := b.tombstones()
-	var (
-		rec     *tombstone.Record
-		leaseID string
-		cl      vmCleanup
-	)
-	if err := b.update(ctx, func(t *vmTx) error {
-		var err error
-		rec, leaseID, err = ts.Recover(ctx, t.w, id, &cl)
-		return err
-	}); err != nil {
-		return false, err
-	}
-	if rec == nil {
-		return false, nil
-	}
-	if err := b.finishVMTeardown(ctx, id, leaseID, cl); err != nil {
-		return false, err
-	}
-	log.WithFunc(b.Typ+".recoverVMTombstone").Warnf(ctx, "rolled forward interrupted delete of VM %s", id)
-	return true, nil
-}
-
 // entryGuard keeps the common no-tombstone path off the single sqlite writer connection.
 func (b *Backend) entryGuard(ctx context.Context, id string) (*VMRecord, error) {
 	ts := b.tombstones()
@@ -142,7 +142,7 @@ func (b *Backend) entryGuard(ctx context.Context, id string) (*VMRecord, error) 
 		return rec, nil
 	}
 	if tsRec.Phase != tombstone.PhaseLeased {
-		if _, rerr := b.recoverVMTombstone(ctx, id); rerr != nil {
+		if _, rerr := b.RecoverTombstone(ctx, id); rerr != nil {
 			return nil, fmt.Errorf("vm %s: recover interrupted delete: %w", id, rerr)
 		}
 		return nil, fmt.Errorf("vm %s was partially deleted; recovery finished the removal: %w", id, ErrNotFound)

--- a/hypervisor/teardown_test.go
+++ b/hypervisor/teardown_test.go
@@ -61,7 +61,7 @@ func TestDeleteProtocolTeardownFailureKeepsTombstoneThenConverges(t *testing.T) 
 		t.Fatalf("record must stay live through deleting: %v", err)
 	}
 	b.SetNetwork(stubNetwork{})
-	done, err := b.recoverVMTombstone(ctx, "vmproto2")
+	done, err := b.RecoverTombstone(ctx, "vmproto2")
 	if err != nil || !done {
 		t.Fatalf("roll forward: done=%v err=%v", done, err)
 	}
@@ -87,7 +87,7 @@ func TestRecoverLeasedRollsBack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	done, err := b.recoverVMTombstone(ctx, "vmproto3")
+	done, err := b.RecoverTombstone(ctx, "vmproto3")
 	if err != nil || done {
 		t.Fatalf("leased must roll back, not finalize: done=%v err=%v", done, err)
 	}
@@ -122,7 +122,7 @@ func TestTombstoneFencingABA(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	done, err := b.recoverVMTombstone(ctx, "vmproto4")
+	done, err := b.RecoverTombstone(ctx, "vmproto4")
 	if err != nil || !done {
 		t.Fatalf("recover: done=%v err=%v", done, err)
 	}

--- a/hypervisor/utils.go
+++ b/hypervisor/utils.go
@@ -40,10 +40,10 @@ const (
 	// CloneLocksDirName holds FC clone locks under the backend run root, outside any VM dir — a clone must be able to lock a source whose dir is already gone.
 	CloneLocksDirName = "clone-locks"
 
-	// restoreDirtyName is cleared only by FinalizeRestore, never by GC.
 	restoreStagingName = ".restore-staging"
-	restoreDirtyName   = ".restore-dirty"
-	captureDirPrefix   = "snapshot-"
+	// restoreDirtyName is cleared only by FinalizeRestore, never by GC.
+	restoreDirtyName = ".restore-dirty"
+	captureDirPrefix = "snapshot-"
 
 	// MinDataDiskSize is the minimum user data disk size; mkfs.ext4 is unstable below this on small sparse files.
 	MinDataDiskSize int64 = 16 << 20

--- a/images/oci/erofs.go
+++ b/images/oci/erofs.go
@@ -29,42 +29,29 @@ var (
 	erofsCheckOK bool
 )
 
-// startErofsConversion pipes a tar stream into mkfs.erofs; caller writes+closes stdin, then cmd.Wait().
-func startErofsConversion(ctx context.Context, uuid, outputPath string) (cmd *exec.Cmd, stdin io.WriteCloser, output *bytes.Buffer, err error) {
+// runErofsConversion streams src into mkfs.erofs while scanning boot files; the scan→drain→close→wait order is load-bearing (full stream before Wait, stdin closed or mkfs.erofs blocks).
+func runErofsConversion(ctx context.Context, src io.Reader, scanDir, namePrefix, uuid, outPath string) (kernelPath, initrdPath string, err error) {
 	if err = checkErofsVersion(ctx); err != nil {
-		return nil, nil, nil, err
+		return "", "", err
 	}
 	// shell out because no Go EROFS writer library; mkfs.erofs is authoritative.
-	cmd = exec.CommandContext( //nolint:gosec
+	cmd := exec.CommandContext( //nolint:gosec
 		ctx, "mkfs.erofs",
 		"--tar=f",
 		fmt.Sprintf("-z%s", erofsCompression),
 		fmt.Sprintf("-C%d", erofsBlockSize),
 		"-T0",
 		"-U", uuid,
-		outputPath,
+		outPath,
 	)
-
-	stdin, err = cmd.StdinPipe()
+	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("create stdin pipe: %w", err)
+		return "", "", fmt.Errorf("create stdin pipe: %w", err)
 	}
-
-	output = &bytes.Buffer{}
-	cmd.Stdout = output
-	cmd.Stderr = output
-
+	var output bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &output, &output
 	if err = cmd.Start(); err != nil {
-		return nil, nil, nil, fmt.Errorf("start mkfs.erofs: %w", err)
-	}
-	return cmd, stdin, output, nil
-}
-
-// runErofsConversion streams src into mkfs.erofs while scanning boot files; the scan→drain→close→wait order is load-bearing (full stream before Wait, stdin closed or mkfs.erofs blocks).
-func runErofsConversion(ctx context.Context, src io.Reader, scanDir, namePrefix, uuid, outPath string) (kernelPath, initrdPath string, err error) {
-	cmd, stdin, output, err := startErofsConversion(ctx, uuid, outPath)
-	if err != nil {
-		return "", "", fmt.Errorf("start erofs conversion: %w", err)
+		return "", "", fmt.Errorf("start mkfs.erofs: %w", err)
 	}
 
 	tee := io.TeeReader(src, stdin)

--- a/meta/broadcast.go
+++ b/meta/broadcast.go
@@ -66,9 +66,7 @@ func (b *Broadcaster) Stop() {
 // Run is the notifier goroutine body: watcher events are debounced; watcher errors, the optional extra trigger and a safety poll check immediately.
 func (b *Broadcaster) Run(check func(), extra <-chan struct{}) {
 	timer := time.NewTimer(0)
-	if !timer.Stop() {
-		<-timer.C
-	}
+	timer.Stop()
 	pending := false
 	poll := time.NewTicker(eventsSafetyPoll)
 	defer poll.Stop()

--- a/network/bridge/bridge_linux.go
+++ b/network/bridge/bridge_linux.go
@@ -151,8 +151,7 @@ func (b *Bridge) RegisterGC(orch *gc.Orchestrator) {
 }
 
 // CleanupTAPs removes bridge TAP devices per VM ID; safe without a Bridge instance.
-func CleanupTAPs(tapPrefix string, vmIDs []string) []string {
-	cleaned := make([]string, 0, len(vmIDs))
+func CleanupTAPs(tapPrefix string, vmIDs []string) {
 	for _, vmID := range vmIDs {
 		var indices []int
 		for i := 0; ; i++ {
@@ -162,9 +161,7 @@ func CleanupTAPs(tapPrefix string, vmIDs []string) []string {
 			indices = append(indices, i)
 		}
 		_ = tearDownTAPs(tapPrefix, vmID, indices, true)
-		cleaned = append(cleaned, vmID)
 	}
-	return cleaned
 }
 
 // attachBridgeUp enslaves a TAP to the bridge, applies MTU/txqlen/GRO tuning and brings it up in one RTM_SETLINK, paying the node-wide rtnl lock once.

--- a/network/bridge/bridge_other.go
+++ b/network/bridge/bridge_other.go
@@ -44,4 +44,4 @@ func (b *Bridge) Add(_ context.Context, _ string, _ *types.VMConfig, _ ...networ
 
 func (b *Bridge) Delete(_ context.Context, _ string) error { return errUnsupported }
 
-func CleanupTAPs(_ string, _ []string) []string { return nil }
+func CleanupTAPs(_ string, _ []string) {}

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -132,9 +132,7 @@ func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []n
 		}
 		if cl != nil {
 			if err := c.cniDel(ctx, cl, vmID, nsPath, rec.IfName); err != nil {
-				if recErr == nil {
-					recErr = fmt.Errorf("cni del %s/%s: %w", vmID, rec.IfName, err)
-				}
+				recErr = errors.Join(recErr, fmt.Errorf("cni del %s/%s: %w", vmID, rec.IfName, err))
 				logger.Warnf(ctx, "CNI DEL %s/%s: %v", vmID, rec.IfName, err)
 			}
 		}
@@ -143,9 +141,7 @@ func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []n
 			if !ok {
 				logger.Warnf(ctx, "parse ifname %q for %s (skip tap delete)", rec.IfName, vmID)
 			} else if delErr := deleteTAPFn(nsPath, tapNameForVM(vmID, idx)); delErr != nil {
-				if recErr == nil {
-					recErr = fmt.Errorf("delete tap %s: %w", tapNameForVM(vmID, idx), delErr)
-				}
+				recErr = errors.Join(recErr, fmt.Errorf("delete tap %s: %w", tapNameForVM(vmID, idx), delErr))
 				logger.Warnf(ctx, "delete tap %s in netns %s: %v", tapNameForVM(vmID, idx), nsPath, delErr)
 			}
 		}

--- a/utils/file.go
+++ b/utils/file.go
@@ -29,15 +29,7 @@ func SameFilesystem(a, b string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	da, ok := sa.Sys().(*syscall.Stat_t)
-	if !ok {
-		return false, nil
-	}
-	db, ok := sb.Sys().(*syscall.Stat_t)
-	if !ok {
-		return false, nil
-	}
-	return da.Dev == db.Dev, nil
+	return sa.Sys().(*syscall.Stat_t).Dev == sb.Sys().(*syscall.Stat_t).Dev, nil
 }
 
 // EnsureDirs creates all directories with 0o750 permissions.

--- a/utils/watch.go
+++ b/utils/watch.go
@@ -32,9 +32,7 @@ func watchLoop(ctx context.Context, watcher *fsnotify.Watcher, base string, debo
 	defer watcher.Close() //nolint:errcheck
 
 	timer := time.NewTimer(0)
-	if !timer.Stop() {
-		<-timer.C
-	}
+	timer.Stop()
 	pending := false
 
 	for {


### PR DESCRIPTION
## Why

The hygiene ledger listed 107 production files whose blobs changed since the judge lens (/simplify + /loc-justify) last cleared them, almost all from the #221 comment/layout round and the #222 fold. Five readers covered every one in full; this PR applies the findings that are behaviour-preserving and below the structural line. Cut-list items (a dead platform stub, a review-round sync.Pool, a callback-shaped pipe helper) stay in the round report for a decision.

## What

- gc: bare `snap.(S)` assertions (the orchestrator always pairs a module with its own snapshot; a shared Name would now fail loudly instead of silently skipping a GC pass); resolve and collect run in one pass since Resolve reads only the frozen snapshot map.
- hypervisor: `BinaryName`/`PIDFileName` move from the two backend `Config`s onto `BaseConfig`; `recoverVMTombstone` takes the exported `RecoverTombstone` name and its forwarder goes.
- images/oci: `startErofsConversion` inlined into its only caller (the version check stays on both the pull and import paths).
- meta/broadcast, utils/watch: the pre-1.23 `if !timer.Stop() { <-timer.C }` drain is dead under go 1.27's unbuffered timer channels.
- network: `CleanupTAPs` drops a return value no caller read (cocoon-macos defers it as a statement, verified to build through go.work); `tearDownNICs` joins both per-record failures instead of keeping the first.
- utils: `SameFilesystem` asserts `*syscall.Stat_t` directly; the comma-ok fallbacks answered "different filesystem" on a type the file cannot compile without.
- cmd: `units.RAMInBytes` already rejects negatives; the digest display truncation is `min()`.
- Three comments the layout round left adrift: the `LaunchSpec` godoc dangling at end of file, the `restoreDirtyName` comment sitting above `restoreStagingName`, and `recordExistsFn`'s doc claiming liveness.

Net −61 prod lines, −4 comment lines, no new comments, no behaviour change on any reachable path.

## Evidence

`GOWORK=off make fmt-check` rc=0; `GOWORK=off make lint` rc=0 with two `0 issues` lines (linux + darwin); `asl -forwarder=false ./...` clean on both GOOS; `GOWORK=off go test -race -count=1 -timeout 15m ./...` 35 packages ok, 0 FAIL lines (log kept locally); `go build ./...` in cocoon-macos through the workspace go.work succeeds against this branch.