### PR TITLE
perf: coalesce tar extraction into one write or seek per run of blocks

### DIFF
--- a/utils/tar.go
+++ b/utils/tar.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"slices"
 	"strconv"
-	"sync"
 )
 
 const (
@@ -20,14 +19,9 @@ const (
 
 	// sparseBlockSize is the zero-detection block size during extraction.
 	sparseBlockSize = 4096
+	// extractReadBuf bounds one read; runs of data or zero blocks inside it coalesce into one write or one seek.
+	extractReadBuf = 1 << 20
 )
-
-var sparseBlockPool = sync.Pool{
-	New: func() any {
-		b := make([]byte, sparseBlockSize)
-		return &b
-	},
-}
 
 // sparseSegment describes one contiguous data region in a sparse file.
 type sparseSegment struct {
@@ -85,7 +79,7 @@ func ExtractTar(dir string, r io.Reader, skip ...func(name string) bool) error {
 				return fmt.Errorf("extract sparse %s: %w", name, err)
 			}
 		} else {
-			if err := extractFile(outPath, tr, hdr.FileInfo().Mode()); err != nil {
+			if err := extractFile(outPath, tr, hdr.FileInfo().Mode(), hdr.Size); err != nil {
 				return fmt.Errorf("extract %s: %w", name, err)
 			}
 		}
@@ -139,29 +133,38 @@ func extractFileSparse(path string, r io.Reader, perm os.FileMode, realSize int6
 	return nil
 }
 
-func extractFile(path string, r io.Reader, perm os.FileMode) (err error) {
+func extractFile(path string, r io.Reader, perm os.FileMode, size int64) (err error) {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm) //nolint:gosec
 	if err != nil {
 		return err
 	}
 	defer func() { err = errors.Join(err, f.Close()) }()
 
-	bp := sparseBlockPool.Get().(*[]byte)
-	buf := *bp
-	defer sparseBlockPool.Put(bp)
+	buf := make([]byte, min(int64(extractReadBuf), max(size, sparseBlockSize)))
 	var total int64
 	endsWithHole := false
 
 	for {
 		n, readErr := io.ReadFull(r, buf)
-		if n > 0 {
-			var writeErr error
-			endsWithHole, writeErr = writeBlockSparse(f, buf[:n])
-			if writeErr != nil {
-				return writeErr
+		for chunk := buf[:n]; len(chunk) > 0; {
+			hole := isAllZero(chunk[:min(sparseBlockSize, len(chunk))])
+			run := min(sparseBlockSize, len(chunk))
+			for run < len(chunk) && isAllZero(chunk[run:min(run+sparseBlockSize, len(chunk))]) == hole {
+				run += sparseBlockSize
 			}
-			total += int64(n)
+			run = min(run, len(chunk))
+			if hole {
+				_, err = f.Seek(int64(run), io.SeekCurrent)
+			} else {
+				_, err = f.Write(chunk[:run])
+			}
+			if err != nil {
+				return err
+			}
+			endsWithHole = hole
+			chunk = chunk[run:]
 		}
+		total += int64(n)
 		if errors.Is(readErr, io.EOF) || errors.Is(readErr, io.ErrUnexpectedEOF) {
 			break
 		}
@@ -178,16 +181,6 @@ func extractFile(path string, r io.Reader, perm os.FileMode) (err error) {
 	}
 
 	return nil
-}
-
-// writeBlockSparse seeks over all-zero chunks instead of writing them.
-func writeBlockSparse(f *os.File, chunk []byte) (hole bool, err error) {
-	if isAllZero(chunk) {
-		_, err = f.Seek(int64(len(chunk)), io.SeekCurrent)
-		return true, err
-	}
-	_, err = f.Write(chunk)
-	return false, err
 }
 
 func isAllZero(b []byte) bool {

--- a/utils/tar_test.go
+++ b/utils/tar_test.go
@@ -509,12 +509,45 @@ func TestExtractTar_Sparse_MixedWithRegularEntries(t *testing.T) {
 	}
 }
 
+func TestExtractFile_RunsAcrossReadBuffer(t *testing.T) {
+	data := make([]byte, extractReadBuf+3*sparseBlockSize)
+	for i := 0; i < sparseBlockSize; i++ {
+		data[i] = 0xA5
+	}
+	for i := extractReadBuf + sparseBlockSize; i < extractReadBuf+2*sparseBlockSize; i++ {
+		data[i] = 0x5A
+	}
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(&tar.Header{Name: "memory", Mode: 0o600, Size: int64(len(data)), Typeflag: tar.TypeReg}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	if err := ExtractTar(dir, &buf); err != nil {
+		t.Fatalf("ExtractTar: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "memory"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("extracted %d bytes differ from the %d-byte source (zero run across the read buffer, trailing hole)", len(got), len(data))
+	}
+}
+
 func TestExtractFile_AllZeroBlocks(t *testing.T) {
 	data := make([]byte, 12*1024)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "zeros.bin")
 
-	if err := extractFile(path, bytes.NewReader(data), 0o644); err != nil {
+	if err := extractFile(path, bytes.NewReader(data), 0o644, int64(len(data))); err != nil {
 		t.Fatal(err)
 	}
 
@@ -535,7 +568,7 @@ func TestExtractFile_NoZeroBlocks(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "dense.bin")
 
-	if err := extractFile(path, bytes.NewReader(data), 0o644); err != nil {
+	if err := extractFile(path, bytes.NewReader(data), 0o644, int64(len(data))); err != nil {
 		t.Fatal(err)
 	}
 
@@ -556,7 +589,7 @@ func TestExtractFile_MixedZeroAndData(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "mixed.bin")
 
-	if err := extractFile(path, bytes.NewReader(data), 0o644); err != nil {
+	if err := extractFile(path, bytes.NewReader(data), 0o644, int64(len(data))); err != nil {
 		t.Fatal(err)
 	}
 
@@ -577,7 +610,7 @@ func TestExtractFile_EndsWithHole(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "endhole.bin")
 
-	if err := extractFile(path, bytes.NewReader(data), 0o644); err != nil {
+	if err := extractFile(path, bytes.NewReader(data), 0o644, int64(len(data))); err != nil {
 		t.Fatal(err)
 	}
 
@@ -595,7 +628,7 @@ func TestExtractFile_PartialBlock(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "partial.bin")
 
-	if err := extractFile(path, bytes.NewReader(data), 0o644); err != nil {
+	if err := extractFile(path, bytes.NewReader(data), 0o644, int64(len(data))); err != nil {
 		t.Fatal(err)
 	}
 
@@ -613,7 +646,7 @@ func TestExtractFile_PartialZeroBlock(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "pzero.bin")
 
-	if err := extractFile(path, bytes.NewReader(data), 0o644); err != nil {
+	if err := extractFile(path, bytes.NewReader(data), 0o644, int64(len(data))); err != nil {
 		t.Fatal(err)
 	}
 
@@ -633,7 +666,7 @@ func TestExtractFile_EmptyInput(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "empty.bin")
 
-	if err := extractFile(path, bytes.NewReader(nil), 0o644); err != nil {
+	if err := extractFile(path, bytes.NewReader(nil), 0o644, 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -650,7 +683,7 @@ func TestExtractFile_SingleByte(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "single.bin")
 
-	if err := extractFile(path, bytes.NewReader([]byte{0x42}), 0o644); err != nil {
+	if err := extractFile(path, bytes.NewReader([]byte{0x42}), 0o644, 1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -667,7 +700,7 @@ func TestExtractFile_SingleZeroByte(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "onezero.bin")
 
-	if err := extractFile(path, bytes.NewReader([]byte{0x00}), 0o644); err != nil {
+	if err := extractFile(path, bytes.NewReader([]byte{0x00}), 0o644, 1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -705,53 +738,6 @@ func TestIsAllZero(t *testing.T) {
 				t.Errorf("isAllZero: got %v, want %v", got, tt.want)
 			}
 		})
-	}
-}
-
-func TestWriteBlockSparse_DataBlock(t *testing.T) {
-	dir := t.TempDir()
-	f, err := os.Create(filepath.Join(dir, "data.bin"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer f.Close() //nolint:errcheck
-
-	chunk := []byte{1, 2, 3, 4}
-	hole, err := writeBlockSparse(f, chunk)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if hole {
-		t.Error("expected hole=false for data block")
-	}
-
-	f.Seek(0, io.SeekStart) //nolint:errcheck
-	got, _ := io.ReadAll(f)
-	if !bytes.Equal(got, chunk) {
-		t.Errorf("got %v, want %v", got, chunk)
-	}
-}
-
-func TestWriteBlockSparse_ZeroBlock(t *testing.T) {
-	dir := t.TempDir()
-	f, err := os.Create(filepath.Join(dir, "hole.bin"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer f.Close() //nolint:errcheck
-
-	chunk := make([]byte, 4096)
-	hole, err := writeBlockSparse(f, chunk)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !hole {
-		t.Error("expected hole=true for zero block")
-	}
-
-	pos, _ := f.Seek(0, io.SeekCurrent)
-	if pos != 4096 {
-		t.Errorf("position: got %d, want 4096", pos)
 	}
 }
 


### PR DESCRIPTION
## Why

`extractFile` issued one `write` or one `lseek` per 4 KiB block for the whole entry. A hole-free multi-GiB memory file (tarred through `rewindAndTarFull` with no sparse map, the shape a warm VM's memory produces) therefore cost about 262k syscalls per GiB on `hypervisor/restore.go`, `hypervisor/clone.go` and `snapshot/localfile.Create` from a stream. Measured on hardware before touching code, as agreed in the 2026-09-12 round.

## What

- Read up to 1 MiB per iteration (bounded by the entry size, so small entries allocate 4 KiB as before), scan the same 4 KiB sub-blocks, and turn each run of data blocks into one `write` and each run of zero blocks into one `seek`. Hole granularity, zero detection and the trailing `Truncate` are unchanged.
- The `sync.Pool` around the old 4 KiB buffer goes with it (measured below: 2 µs per entry).
- `writeBlockSparse` folds into the loop; its two unit tests are covered by the `TestExtractFile_*` set, and a new test pins a zero run that straddles the read-buffer boundary plus a trailing hole.

## Measurement (cocoon-test2, XFS on NVMe, `tarbench` cross-built from this algorithm)

2 GiB entry, 30 % zero blocks in PRNG runs, 5 reps per arm interleaved, then the order swapped:

| arm | order AB median | order BA median | write syscalls | seeks | sha256 |
|---|---|---|---|---|---|
| A production | 1.625 s | 1.535 s | 365,125 | ≈159k | ca840779… |
| B coalesced | 0.397 s | 0.319 s | 3,205 | 2,359 | ca840779… |

Allocated blocks differed by 0.5 % (4,156,464 vs 4,178,104 × 512 B), an XFS allocation artifact of larger sequential writes, not a hole-layout change; contents are byte-identical.

Pooled vs per-entry 4 KiB buffer, 20,000 entries of 4 KiB: 31 µs vs 33 µs per entry in both orders.

## Evidence

`go test -race -count=1 ./utils/ ./snapshot/... ./hypervisor/ ./hypervisor/cloudhypervisor/ ./hypervisor/firecracker/` ok; `make fmt-check` rc=0; `make lint` two `0 issues` lines; `asl -forwarder=false ./...` clean on both GOOS. Comment lines +1/−1.