### PR TITLE
fix: derive disk queue affinity from the VM's own cpuset placement

### DIFF
--- a/cgroup/cgroup.go
+++ b/cgroup/cgroup.go
@@ -102,15 +102,6 @@ func (k Knobs) Validate() error {
 	return nil
 }
 
-// EffectiveCPUs resolves the cpu set a VM may run on — explicit placement wins over the machine fence; nil means all cores.
-func EffectiveCPUs(placement, fence string) []int {
-	cpus, err := ParseCPUList(cmp.Or(placement, fence))
-	if err != nil {
-		return nil
-	}
-	return cpus
-}
-
 // ParseCPUList parses a kernel cpu-list ("0-14", "0,2-4"); empty input is nil (no placement).
 func ParseCPUList(s string) ([]int, error) {
 	if s == "" {

--- a/cgroup/cgroup_test.go
+++ b/cgroup/cgroup_test.go
@@ -262,18 +262,6 @@ func TestPlaceScopeReadGate(t *testing.T) {
 	}
 }
 
-func TestEffectiveCPUs(t *testing.T) {
-	if got := EffectiveCPUs("2-3", "0-14"); !slices.Equal(got, []int{2, 3}) {
-		t.Errorf("placement wins: got %v", got)
-	}
-	if got := EffectiveCPUs("", "0-1"); !slices.Equal(got, []int{0, 1}) {
-		t.Errorf("fence fallback: got %v", got)
-	}
-	if EffectiveCPUs("", "") != nil {
-		t.Error("no constraint: want nil")
-	}
-}
-
 func TestArmSetsQuotaThenBurst(t *testing.T) {
 	parent := t.TempDir()
 	dir := ScopeDir(parent, "A")

--- a/cmd/vm/debug.go
+++ b/cmd/vm/debug.go
@@ -9,9 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/cocoonstack/cocoon/cgroup"
 	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
-	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/hypervisor"
 	"github.com/cocoonstack/cocoon/hypervisor/cloudhypervisor"
 	"github.com/cocoonstack/cocoon/hypervisor/firecracker"
@@ -19,14 +17,14 @@ import (
 )
 
 type chDebugSpec struct {
-	Configs []*types.StorageConfig
-	Boot    *types.BootConfig
-	VMCfg   *types.VMConfig
-	CowPath string
-	CHBin   string
-	MaxCPU  int
-	Balloon int
-	Allowed []int
+	Configs   []*types.StorageConfig
+	Boot      *types.BootConfig
+	VMCfg     *types.VMConfig
+	CowPath   string
+	CHBin     string
+	MaxCPU    int
+	Balloon   int
+	Placement []int
 }
 
 func (h Handler) Debug(cmd *cobra.Command, args []string) error {
@@ -69,7 +67,7 @@ func (h Handler) Debug(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	printCHDebug(buildCHDebugSpec(cmd, conf, storageConfigs, boot, vmCfg))
+	printCHDebug(buildCHDebugSpec(cmd, storageConfigs, boot, vmCfg))
 	return nil
 }
 
@@ -139,7 +137,7 @@ func printFCDebug(configs []*types.StorageConfig, boot *types.BootConfig, vmCfg 
 	fmt.Println("  -d '{\"action_type\": \"InstanceStart\"}'")
 }
 
-func buildCHDebugSpec(cmd *cobra.Command, conf *config.Config, storageConfigs []*types.StorageConfig, boot *types.BootConfig, vmCfg *types.VMConfig) chDebugSpec {
+func buildCHDebugSpec(cmd *cobra.Command, storageConfigs []*types.StorageConfig, boot *types.BootConfig, vmCfg *types.VMConfig) chDebugSpec {
 	maxCPU, _ := cmd.Flags().GetInt("max-cpu")
 	balloon, _ := cmd.Flags().GetInt("balloon")
 	cowPath, _ := cmd.Flags().GetString("cow")
@@ -152,16 +150,16 @@ func buildCHDebugSpec(cmd *cobra.Command, conf *config.Config, storageConfigs []
 	case balloon == 0:
 		balloon = int(size >> 20) //nolint:mnd
 	}
-	allowed := cgroup.EffectiveCPUs(vmCfg.CPUSetCPUs, conf.CgroupCPUFence())
+	placement := hypervisor.PlacementCPUs(&vmCfg.Config)
 	return chDebugSpec{
-		Configs: storageConfigs,
-		Boot:    boot,
-		VMCfg:   vmCfg,
-		Allowed: allowed,
-		CowPath: cowPath,
-		CHBin:   chBin,
-		MaxCPU:  maxCPU,
-		Balloon: balloon,
+		Configs:   storageConfigs,
+		Boot:      boot,
+		VMCfg:     vmCfg,
+		Placement: placement,
+		CowPath:   cowPath,
+		CHBin:     chBin,
+		MaxCPU:    maxCPU,
+		Balloon:   balloon,
 	}
 }
 
@@ -175,7 +173,7 @@ func printCHDebug(s chDebugSpec) {
 		debugConfigs := slices.Concat(s.Configs, []*types.StorageConfig{
 			{Path: s.CowPath, RO: false, Serial: hypervisor.CowSerial},
 		})
-		diskArgs := cloudhypervisor.DebugDiskCLIArgs(debugConfigs, cpu, diskQueueSize, noDirectIO, s.Allowed)
+		diskArgs := cloudhypervisor.DebugDiskCLIArgs(debugConfigs, cpu, diskQueueSize, noDirectIO, s.Placement)
 		cocoonLayers := strings.Join(cloudhypervisor.ReverseLayerSerials(s.Configs), ",")
 		cmdline := hypervisor.BuildBaseCmdline("console=hvc0 loglevel=3",
 			cocoonLayers, hypervisor.CowSerial, nil, s.VMCfg.Name, nil)
@@ -204,7 +202,7 @@ func printCHDebug(s chDebugSpec) {
 		fmt.Printf("%s \\\n", s.CHBin)
 		fmt.Printf("  --firmware %s \\\n", s.Boot.FirmwarePath)
 		fmt.Print("  --disk \\\n")
-		diskArgs := cloudhypervisor.DebugDiskCLIArgs([]*types.StorageConfig{{Path: s.CowPath, RO: false}}, cpu, diskQueueSize, noDirectIO, s.Allowed)
+		diskArgs := cloudhypervisor.DebugDiskCLIArgs([]*types.StorageConfig{{Path: s.CowPath, RO: false}}, cpu, diskQueueSize, noDirectIO, s.Placement)
 		fmt.Printf("    \"%s\" \\\n", diskArgs[0])
 	}
 	printCommonCHArgs(s)

--- a/cmd/vm/debug.go
+++ b/cmd/vm/debug.go
@@ -150,16 +150,15 @@ func buildCHDebugSpec(cmd *cobra.Command, storageConfigs []*types.StorageConfig,
 	case balloon == 0:
 		balloon = int(size >> 20) //nolint:mnd
 	}
-	placement := hypervisor.PlacementCPUs(&vmCfg.Config)
 	return chDebugSpec{
 		Configs:   storageConfigs,
 		Boot:      boot,
 		VMCfg:     vmCfg,
-		Placement: placement,
 		CowPath:   cowPath,
 		CHBin:     chBin,
 		MaxCPU:    maxCPU,
 		Balloon:   balloon,
+		Placement: hypervisor.PlacementCPUs(&vmCfg.Config),
 	}
 }
 

--- a/hypervisor/cloudhypervisor/args.go
+++ b/hypervisor/cloudhypervisor/args.go
@@ -30,10 +30,10 @@ func (b *kvBuilder) addIf(cond bool, kv string) {
 }
 
 // DebugDiskCLIArgs uses the same storage-to-disk mapping as launch.
-func DebugDiskCLIArgs(storageConfigs []*types.StorageConfig, cpuCount, diskQueueSize int, noDirectIO bool, allowed []int) []string {
+func DebugDiskCLIArgs(storageConfigs []*types.StorageConfig, cpuCount, diskQueueSize int, noDirectIO bool, placement []int) []string {
 	args := make([]string, 0, len(storageConfigs))
 	for _, storageConfig := range storageConfigs {
-		args = append(args, diskToCLIArg(storageConfigToDisk(storageConfig, cpuCount, diskQueueSize, noDirectIO, allowed)))
+		args = append(args, diskToCLIArg(storageConfigToDisk(storageConfig, cpuCount, diskQueueSize, noDirectIO, placement)))
 	}
 	return args
 }
@@ -43,7 +43,7 @@ func DebugMemoryCLIArg(cfg *types.Config) string {
 	return memoryCLIArg(chMemory{Size: cfg.Memory, HugePages: cfg.HugePages, Shared: cfg.SharedMemory, Mergeable: cfg.Mergeable})
 }
 
-func buildVMConfig(rec *hypervisor.VMRecord, consoleSockPath string, allowed []int) *chVMConfig {
+func buildVMConfig(rec *hypervisor.VMRecord, consoleSockPath string, placement []int) *chVMConfig {
 	cpu := rec.Config.CPU
 	mem := rec.Config.Memory
 
@@ -66,7 +66,7 @@ func buildVMConfig(rec *hypervisor.VMRecord, consoleSockPath string, allowed []i
 	}
 
 	for _, storageConfig := range activeDisks(rec) {
-		cfg.Disks = append(cfg.Disks, storageConfigToDisk(storageConfig, cpu, rec.Config.DiskQueueSize, rec.Config.NoDirectIO, allowed))
+		cfg.Disks = append(cfg.Disks, storageConfigToDisk(storageConfig, cpu, rec.Config.DiskQueueSize, rec.Config.NoDirectIO, placement))
 	}
 
 	for _, nc := range rec.NetworkConfigs {
@@ -192,7 +192,7 @@ func effectiveDirectIO(sc *types.StorageConfig, noDirectIO bool) bool {
 	return !sc.RO && !noDirectIO
 }
 
-func storageConfigToDisk(storageConfig *types.StorageConfig, cpuCount, diskQueueSize int, noDirectIO bool, allowed []int) chDisk {
+func storageConfigToDisk(storageConfig *types.StorageConfig, cpuCount, diskQueueSize int, noDirectIO bool, placement []int) chDisk {
 	diskQueueSize = utils.OrDefault(diskQueueSize, defaultDiskQueueSize)
 	d := chDisk{
 		Path:      storageConfig.Path,
@@ -215,20 +215,19 @@ func storageConfigToDisk(storageConfig *types.StorageConfig, cpuCount, diskQueue
 	}
 
 	if cpuCount > 1 && !storageConfig.RO {
-		d.QueueAffinity = queueAffinity(cpuCount, allowed)
+		d.QueueAffinity = queueAffinity(cpuCount, placement)
 	}
 	return d
 }
 
-// queueAffinity clamps to the allowed set so no queue targets a core the scope cannot run on; nil allowed keeps the identity mapping.
-func queueAffinity(cpuCount int, allowed []int) []chQueueAffinity {
+// queueAffinity spreads the queues over the cores this VM alone owns; without a placement it pins nothing, since a set the whole VM population shares would land every VM's queue threads on the same cores.
+func queueAffinity(cpuCount int, placement []int) []chQueueAffinity {
+	if len(placement) == 0 {
+		return nil
+	}
 	qa := make([]chQueueAffinity, cpuCount)
 	for i := range qa {
-		host := i
-		if len(allowed) > 0 {
-			host = allowed[i%len(allowed)]
-		}
-		qa[i] = chQueueAffinity{QueueIndex: i, HostCPUs: []int{host}}
+		qa[i] = chQueueAffinity{QueueIndex: i, HostCPUs: []int{placement[i%len(placement)]}}
 	}
 	return qa
 }

--- a/hypervisor/cloudhypervisor/args.go
+++ b/hypervisor/cloudhypervisor/args.go
@@ -214,15 +214,15 @@ func storageConfigToDisk(storageConfig *types.StorageConfig, cpuCount, diskQueue
 		d.Sparse = true
 	}
 
-	if cpuCount > 1 && !storageConfig.RO {
+	if !storageConfig.RO {
 		d.QueueAffinity = queueAffinity(cpuCount, placement)
 	}
 	return d
 }
 
-// queueAffinity spreads the queues over the cores this VM alone owns; without a placement it pins nothing, since a set the whole VM population shares would land every VM's queue threads on the same cores.
+// A core set the whole VM population shares stacks every VM's queue threads onto the same cores, so an unplaced VM pins nothing.
 func queueAffinity(cpuCount int, placement []int) []chQueueAffinity {
-	if len(placement) == 0 {
+	if cpuCount < 2 || len(placement) == 0 {
 		return nil
 	}
 	qa := make([]chQueueAffinity, cpuCount)

--- a/hypervisor/cloudhypervisor/args_cpuset_test.go
+++ b/hypervisor/cloudhypervisor/args_cpuset_test.go
@@ -16,6 +16,7 @@ func TestQueueAffinityFollowsPlacement(t *testing.T) {
 		want      [][]int
 	}{
 		{name: "no placement leaves the queues unpinned", cpu: 3},
+		{name: "a single queue is never pinned", cpu: 1, placement: []int{8, 9}},
 		{name: "round-robin within the placement", cpu: 4, placement: []int{8, 9}, want: [][]int{{8}, {9}, {8}, {9}}},
 	}
 	for _, tt := range tests {

--- a/hypervisor/cloudhypervisor/args_cpuset_test.go
+++ b/hypervisor/cloudhypervisor/args_cpuset_test.go
@@ -13,31 +13,48 @@ func TestQueueAffinityFollowsPlacement(t *testing.T) {
 		name      string
 		cpu       int
 		placement []int
-		want      [][]int
+		want      []chQueueAffinity
 	}{
 		{name: "no placement leaves the queues unpinned", cpu: 3},
 		{name: "a single queue is never pinned", cpu: 1, placement: []int{8, 9}},
-		{name: "round-robin within the placement", cpu: 4, placement: []int{8, 9}, want: [][]int{{8}, {9}, {8}, {9}}},
+		{name: "round-robin within the placement", cpu: 4, placement: []int{8, 9}, want: []chQueueAffinity{
+			{QueueIndex: 0, HostCPUs: []int{8}},
+			{QueueIndex: 1, HostCPUs: []int{9}},
+			{QueueIndex: 2, HostCPUs: []int{8}},
+			{QueueIndex: 3, HostCPUs: []int{9}},
+		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			qa := queueAffinity(tt.cpu, tt.placement)
-			if len(qa) != len(tt.want) {
-				t.Fatalf("got %d entries, want %d", len(qa), len(tt.want))
-			}
-			for i, a := range qa {
-				if a.QueueIndex != i || !slices.Equal(a.HostCPUs, tt.want[i]) {
-					t.Errorf("queue %d: got %v, want %v", i, a.HostCPUs, tt.want[i])
-				}
+			if got := queueAffinity(tt.cpu, tt.placement); !slices.EqualFunc(got, tt.want, sameQueueAffinity) {
+				t.Errorf("got %+v, want %+v", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestDiskCLIArgOmitsQueueAffinityWithoutPlacement(t *testing.T) {
-	sc := &types.StorageConfig{Path: "/v/cow.raw", Role: types.StorageRoleCOW}
-	got := diskToCLIArg(storageConfigToDisk(sc, 8, 0, false, nil))
-	if strings.Contains(got, "queue_affinity") {
-		t.Errorf("unplaced VMs must not pin queue threads onto the low core ids every other VM also picks: %s", got)
+func TestDiskCLIArgQueueAffinity(t *testing.T) {
+	tests := []struct {
+		name      string
+		placement []int
+		want      string
+	}{
+		{name: "unplaced VMs must not pin queue threads onto the low core ids every other VM also picks", placement: nil},
+		{name: "a placement renders one host cpu per queue", placement: []int{8, 9}, want: "queue_affinity=[0@[8],1@[9],2@[8],3@[9]]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := &types.StorageConfig{Path: "/v/cow.raw", Role: types.StorageRoleCOW}
+			got := diskToCLIArg(storageConfigToDisk(sc, 4, 0, false, tt.placement))
+			if tt.want == "" {
+				if strings.Contains(got, "queue_affinity") {
+					t.Errorf("got %s, want no queue_affinity", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("got %s, want it to contain %s", got, tt.want)
+			}
+		})
 	}
 }

--- a/hypervisor/cloudhypervisor/args_cpuset_test.go
+++ b/hypervisor/cloudhypervisor/args_cpuset_test.go
@@ -2,27 +2,41 @@ package cloudhypervisor
 
 import (
 	"slices"
+	"strings"
 	"testing"
+
+	"github.com/cocoonstack/cocoon/types"
 )
 
-func TestQueueAffinityClamp(t *testing.T) {
+func TestQueueAffinityFollowsPlacement(t *testing.T) {
 	tests := []struct {
-		name    string
-		cpu     int
-		allowed []int
-		want    [][]int
+		name      string
+		cpu       int
+		placement []int
+		want      [][]int
 	}{
-		{name: "identity without allowance", cpu: 3, want: [][]int{{0}, {1}, {2}}},
-		{name: "clamped round-robin", cpu: 4, allowed: []int{8, 9}, want: [][]int{{8}, {9}, {8}, {9}}},
+		{name: "no placement leaves the queues unpinned", cpu: 3},
+		{name: "round-robin within the placement", cpu: 4, placement: []int{8, 9}, want: [][]int{{8}, {9}, {8}, {9}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			qa := queueAffinity(tt.cpu, tt.allowed)
+			qa := queueAffinity(tt.cpu, tt.placement)
+			if len(qa) != len(tt.want) {
+				t.Fatalf("got %d entries, want %d", len(qa), len(tt.want))
+			}
 			for i, a := range qa {
 				if a.QueueIndex != i || !slices.Equal(a.HostCPUs, tt.want[i]) {
 					t.Errorf("queue %d: got %v, want %v", i, a.HostCPUs, tt.want[i])
 				}
 			}
 		})
+	}
+}
+
+func TestDiskCLIArgOmitsQueueAffinityWithoutPlacement(t *testing.T) {
+	sc := &types.StorageConfig{Path: "/v/cow.raw", Role: types.StorageRoleCOW}
+	got := diskToCLIArg(storageConfigToDisk(sc, 8, 0, false, nil))
+	if strings.Contains(got, "queue_affinity") {
+		t.Errorf("unplaced VMs must not pin queue threads onto the low core ids every other VM also picks: %s", got)
 	}
 }

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -96,12 +96,11 @@ func (ch *CloudHypervisor) cloneAfterExtractParsed(ctx context.Context, vmID str
 		netTAPs[i] = network.TAPName(network.RestoreTAPPrefix, vmID, i)
 	}
 
-	consoleSock := hypervisor.ConsoleSockPath(runDir)
 	placementCPUs := hypervisor.PlacementCPUs(&vmCfg.Config)
 	if err = patchCHConfig(chConfigPath, &patchOptions{
 		storageConfigs: patchStorageConfigs,
 		netTAPs:        netTAPs,
-		consoleSock:    consoleSock,
+		consoleSock:    hypervisor.ConsoleSockPath(runDir),
 		vsockSock:      hypervisor.VsockSockPath(runDir),
 		directBoot:     directBoot,
 		diskQueueSize:  vmCfg.DiskQueueSize,

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -27,7 +27,7 @@ type cloneResumeOpts struct {
 	dataDisks           []*types.StorageConfig
 	networkConfigs      []*types.NetworkConfig
 	snapshotCfg         *chVMConfig
-	allowedCPUs         []int
+	placementCPUs       []int
 }
 
 func (ch *CloudHypervisor) Clone(ctx context.Context, vmID string, vmCfg *types.VMConfig, net types.NetSetup, snapshotConfig *types.SnapshotConfig, snapshot io.Reader) (*types.VM, error) {
@@ -97,7 +97,7 @@ func (ch *CloudHypervisor) cloneAfterExtractParsed(ctx context.Context, vmID str
 	}
 
 	consoleSock := hypervisor.ConsoleSockPath(runDir)
-	allowedCPUs := ch.EffectiveCPUs(&vmCfg.Config)
+	placementCPUs := hypervisor.PlacementCPUs(&vmCfg.Config)
 	if err = patchCHConfig(chConfigPath, &patchOptions{
 		storageConfigs: patchStorageConfigs,
 		netTAPs:        netTAPs,
@@ -107,7 +107,7 @@ func (ch *CloudHypervisor) cloneAfterExtractParsed(ctx context.Context, vmID str
 		diskQueueSize:  vmCfg.DiskQueueSize,
 		noDirectIO:     vmCfg.NoDirectIO,
 		cpu:            vmCfg.CPU,
-		allowedCPUs:    allowedCPUs,
+		placementCPUs:  placementCPUs,
 	}); err != nil {
 		return nil, fmt.Errorf("patch CH config: %w", err)
 	}
@@ -143,7 +143,7 @@ func (ch *CloudHypervisor) cloneAfterExtractParsed(ctx context.Context, vmID str
 		dataDisks:           newDataDisks,
 		networkConfigs:      networkConfigs,
 		snapshotCfg:         chCfg,
-		allowedCPUs:         allowedCPUs,
+		placementCPUs:       placementCPUs,
 	}); err != nil {
 		return nil, err
 	}
@@ -182,13 +182,13 @@ func (ch *CloudHypervisor) restoreAndResumeClone(ctx context.Context, pid int, s
 		if i < 0 {
 			return fmt.Errorf("vm.add-disk (cidata): missing storage config")
 		}
-		cidataDisk := storageConfigToDisk(opts.storageConfigs[i], opts.vmCfg.CPU, opts.vmCfg.DiskQueueSize, opts.vmCfg.NoDirectIO, opts.allowedCPUs)
+		cidataDisk := storageConfigToDisk(opts.storageConfigs[i], opts.vmCfg.CPU, opts.vmCfg.DiskQueueSize, opts.vmCfg.NoDirectIO, opts.placementCPUs)
 		if err = addDiskVM(ctx, hc, cidataDisk); err != nil {
 			return fmt.Errorf("vm.add-disk (cidata): %w", err)
 		}
 	}
 	for _, sc := range opts.dataDisks {
-		if err = addDiskVM(ctx, hc, storageConfigToDisk(sc, opts.vmCfg.CPU, opts.vmCfg.DiskQueueSize, opts.vmCfg.NoDirectIO, opts.allowedCPUs)); err != nil {
+		if err = addDiskVM(ctx, hc, storageConfigToDisk(sc, opts.vmCfg.CPU, opts.vmCfg.DiskQueueSize, opts.vmCfg.NoDirectIO, opts.placementCPUs)); err != nil {
 			return fmt.Errorf("vm.add-disk (data %s): %w", sc.Serial, err)
 		}
 	}

--- a/hypervisor/cloudhypervisor/clone_test.go
+++ b/hypervisor/cloudhypervisor/clone_test.go
@@ -196,6 +196,47 @@ func TestPatchCHConfig_RetargetsNetTAPs(t *testing.T) {
 	}
 }
 
+func TestPatchCHConfig_QueueAffinity(t *testing.T) {
+	tests := []struct {
+		name      string
+		placement []int
+		want      []chQueueAffinity
+	}{
+		{name: "no placement drops the source host's mapping", placement: nil},
+		{name: "placement re-derives the mapping", placement: []int{8, 9}, want: []chQueueAffinity{
+			{QueueIndex: 0, HostCPUs: []int{8}},
+			{QueueIndex: 1, HostCPUs: []int{9}},
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfg := baseCHConfig()
+			cfg["disks"].([]any)[1].(map[string]any)["queue_affinity"] = []any{
+				map[string]any{"queue_index": 0, "host_cpus": []any{0}},
+				map[string]any{"queue_index": 1, "host_cpus": []any{1}},
+			}
+			path := writeCHConfig(t, dir, cfg)
+
+			opts := basePatchOpts()
+			opts.cpu = 2
+			opts.placementCPUs = tt.placement
+			if err := patchCHConfig(path, opts); err != nil {
+				t.Fatalf("patchCHConfig: %v", err)
+			}
+
+			patched, err := parseCHConfig(path)
+			if err != nil {
+				t.Fatalf("parseCHConfig: %v", err)
+			}
+			got := patched.Disks[1].QueueAffinity
+			if !slices.EqualFunc(got, tt.want, sameQueueAffinity) {
+				t.Errorf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestUpdateCOWPath_OCI(t *testing.T) {
 	configs := []*types.StorageConfig{
 		{Path: "/old/layer.erofs", RO: true, Serial: "layer0", Role: types.StorageRoleLayer},
@@ -384,6 +425,10 @@ func TestRestoreAndResumeCloneHotplugsCidataByRole(t *testing.T) {
 	if !slices.Equal(added, want) {
 		t.Fatalf("vm.add-disk paths = %v, want %v", added, want)
 	}
+}
+
+func sameQueueAffinity(a, b chQueueAffinity) bool {
+	return a.QueueIndex == b.QueueIndex && slices.Equal(a.HostCPUs, b.HostCPUs)
 }
 
 func writeCHConfig(t *testing.T, dir string, cfg map[string]any) string {

--- a/hypervisor/cloudhypervisor/clone_test.go
+++ b/hypervisor/cloudhypervisor/clone_test.go
@@ -212,10 +212,12 @@ func TestPatchCHConfig_QueueAffinity(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 			cfg := baseCHConfig()
-			cfg["disks"].([]any)[1].(map[string]any)["queue_affinity"] = []any{
+			sourceAffinity := []any{
 				map[string]any{"queue_index": 0, "host_cpus": []any{0}},
 				map[string]any{"queue_index": 1, "host_cpus": []any{1}},
 			}
+			cfg["disks"].([]any)[0].(map[string]any)["queue_affinity"] = sourceAffinity
+			cfg["disks"].([]any)[1].(map[string]any)["queue_affinity"] = sourceAffinity
 			path := writeCHConfig(t, dir, cfg)
 
 			opts := basePatchOpts()
@@ -229,9 +231,11 @@ func TestPatchCHConfig_QueueAffinity(t *testing.T) {
 			if err != nil {
 				t.Fatalf("parseCHConfig: %v", err)
 			}
-			got := patched.Disks[1].QueueAffinity
-			if !slices.EqualFunc(got, tt.want, sameQueueAffinity) {
-				t.Errorf("got %+v, want %+v", got, tt.want)
+			if got := patched.Disks[1].QueueAffinity; !slices.EqualFunc(got, tt.want, sameQueueAffinity) {
+				t.Errorf("cow disk: got %+v, want %+v", got, tt.want)
+			}
+			if got := patched.Disks[0].QueueAffinity; got != nil {
+				t.Errorf("read-only layer: got %+v, want none", got)
 			}
 		})
 	}
@@ -365,7 +369,7 @@ func TestRestorePatchStorageConfigs_KeepsAllWhenSnapshotHadCidata(t *testing.T) 
 	}
 }
 
-func TestRestoreAndResumeCloneHotplugsCidataByRole(t *testing.T) {
+func TestRestoreAndResumeCloneHotplugsByRoleWithPlacement(t *testing.T) {
 	sockDir, err := os.MkdirTemp("", "ch")
 	if err != nil {
 		t.Fatal(err)
@@ -378,7 +382,7 @@ func TestRestoreAndResumeCloneHotplugsCidataByRole(t *testing.T) {
 	}
 	var (
 		mu    sync.Mutex
-		added []string
+		added []chDisk
 	)
 	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "vm.add-disk") {
@@ -388,7 +392,7 @@ func TestRestoreAndResumeCloneHotplugsCidataByRole(t *testing.T) {
 				return
 			}
 			mu.Lock()
-			added = append(added, d.Path)
+			added = append(added, d)
 			mu.Unlock()
 		}
 		w.WriteHeader(http.StatusNoContent)
@@ -415,15 +419,27 @@ func TestRestoreAndResumeCloneHotplugsCidataByRole(t *testing.T) {
 		storageConfigs: storageConfigs,
 		dataDisks:      storageConfigs[2:],
 		snapshotCfg:    &chVMConfig{},
+		placementCPUs:  []int{8, 9},
 	}); err != nil {
 		t.Fatalf("restoreAndResumeClone: %v", err)
 	}
 
 	mu.Lock()
 	defer mu.Unlock()
-	want := []string{"/run/cidata.img", "/run/extra.raw"}
-	if !slices.Equal(added, want) {
-		t.Fatalf("vm.add-disk paths = %v, want %v", added, want)
+	wantPaths := []string{"/run/cidata.img", "/run/extra.raw"}
+	gotPaths := make([]string, len(added))
+	for i, d := range added {
+		gotPaths[i] = d.Path
+	}
+	if !slices.Equal(gotPaths, wantPaths) {
+		t.Fatalf("vm.add-disk paths = %v, want %v", gotPaths, wantPaths)
+	}
+	if got := added[0].QueueAffinity; got != nil {
+		t.Errorf("read-only cidata: got %+v, want none", got)
+	}
+	wantAffinity := []chQueueAffinity{{QueueIndex: 0, HostCPUs: []int{8}}, {QueueIndex: 1, HostCPUs: []int{9}}}
+	if got := added[1].QueueAffinity; !slices.EqualFunc(got, wantAffinity, sameQueueAffinity) {
+		t.Errorf("data disk: got %+v, want %+v", got, wantAffinity)
 	}
 }
 

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -43,7 +43,7 @@ func (ch *CloudHypervisor) DiskAttach(ctx context.Context, vmRef string, spec di
 	makeBody := func(rec *hypervisor.VMRecord) any {
 		d := storageConfigToDisk(&types.StorageConfig{
 			Role: types.StorageRoleData, Path: path, Serial: spec.Name, RO: spec.ReadOnly, DirectIO: spec.DirectIO,
-		}, rec.Config.CPU, rec.Config.DiskQueueSize, rec.Config.NoDirectIO, ch.EffectiveCPUs(&rec.Config.Config))
+		}, rec.Config.CPU, rec.Config.DiskQueueSize, rec.Config.NoDirectIO, hypervisor.PlacementCPUs(&rec.Config.Config))
 		d.ID = id
 		return d
 	}

--- a/hypervisor/cloudhypervisor/patch.go
+++ b/hypervisor/cloudhypervisor/patch.go
@@ -90,7 +90,7 @@ func patchDisks(diskRaw json.RawMessage, opts *patchOptions) (json.RawMessage, e
 		}
 		// A snapshot's affinity targets the source host's cores and must not survive onto this one.
 		delete(elem, "queue_affinity")
-		if affinity != nil && !sc.RO {
+		if len(affinity) > 0 && !sc.RO {
 			if e := setField(elem, "queue_affinity", affinity); e != nil {
 				return e
 			}

--- a/hypervisor/cloudhypervisor/patch.go
+++ b/hypervisor/cloudhypervisor/patch.go
@@ -79,10 +79,7 @@ func patchCHConfig(path string, opts *patchOptions) error {
 
 func patchDisks(diskRaw json.RawMessage, opts *patchOptions) (json.RawMessage, error) {
 	diskQueueSize := utils.OrDefault(opts.diskQueueSize, defaultDiskQueueSize)
-	var affinity []chQueueAffinity
-	if opts.cpu > 1 {
-		affinity = queueAffinity(opts.cpu, opts.placementCPUs)
-	}
+	affinity := queueAffinity(opts.cpu, opts.placementCPUs)
 	return patchRawArray(diskRaw, len(opts.storageConfigs), func(i int, elem map[string]json.RawMessage) error {
 		sc := opts.storageConfigs[i]
 		if e := setField(elem, "path", sc.Path); e != nil {
@@ -91,7 +88,7 @@ func patchDisks(diskRaw json.RawMessage, opts *patchOptions) (json.RawMessage, e
 		if e := setField(elem, "queue_size", diskQueueSize); e != nil {
 			return e
 		}
-		// A snapshot's affinity targets the source host's cores, so drop it before re-deriving under this VM's own placement.
+		// A snapshot's affinity targets the source host's cores and must not survive onto this one.
 		delete(elem, "queue_affinity")
 		if affinity != nil && !sc.RO {
 			if e := setField(elem, "queue_affinity", affinity); e != nil {

--- a/hypervisor/cloudhypervisor/patch.go
+++ b/hypervisor/cloudhypervisor/patch.go
@@ -18,7 +18,7 @@ type patchOptions struct {
 	diskQueueSize  int
 	noDirectIO     bool
 	cpu            int
-	allowedCPUs    []int
+	placementCPUs  []int
 }
 
 // patchCHConfig patches specific fields in config.json while preserving all unknown fields that CH adds internally (platform, cpus.topology, etc.).
@@ -81,7 +81,7 @@ func patchDisks(diskRaw json.RawMessage, opts *patchOptions) (json.RawMessage, e
 	diskQueueSize := utils.OrDefault(opts.diskQueueSize, defaultDiskQueueSize)
 	var affinity []chQueueAffinity
 	if opts.cpu > 1 {
-		affinity = queueAffinity(opts.cpu, opts.allowedCPUs)
+		affinity = queueAffinity(opts.cpu, opts.placementCPUs)
 	}
 	return patchRawArray(diskRaw, len(opts.storageConfigs), func(i int, elem map[string]json.RawMessage) error {
 		sc := opts.storageConfigs[i]
@@ -91,7 +91,8 @@ func patchDisks(diskRaw json.RawMessage, opts *patchOptions) (json.RawMessage, e
 		if e := setField(elem, "queue_size", diskQueueSize); e != nil {
 			return e
 		}
-		// A snapshot's affinity targets are the source host's; re-derive so restore under a different fence/placement cannot aim at cores the scope no longer owns.
+		// A snapshot's affinity targets the source host's cores, so drop it before re-deriving under this VM's own placement.
+		delete(elem, "queue_affinity")
 		if affinity != nil && !sc.RO {
 			if e := setField(elem, "queue_affinity", affinity); e != nil {
 				return e

--- a/hypervisor/cloudhypervisor/restore.go
+++ b/hypervisor/cloudhypervisor/restore.go
@@ -83,7 +83,7 @@ func (ch *CloudHypervisor) restoreAfterExtract(ctx context.Context, vmID string,
 		diskQueueSize:  vmCfg.DiskQueueSize,
 		noDirectIO:     vmCfg.NoDirectIO,
 		cpu:            vmCfg.CPU,
-		allowedCPUs:    ch.EffectiveCPUs(&vmCfg.Config),
+		placementCPUs:  hypervisor.PlacementCPUs(&vmCfg.Config),
 	}); err != nil {
 		return nil, fmt.Errorf("patch config: %w", err)
 	}

--- a/hypervisor/cloudhypervisor/start.go
+++ b/hypervisor/cloudhypervisor/start.go
@@ -19,7 +19,7 @@ func (ch *CloudHypervisor) startOne(ctx context.Context, id string) error {
 	return ch.StartSequence(ctx, id, hypervisor.StartSpec{
 		RuntimeFiles: runtimeFiles,
 		Launch: func(ctx context.Context, rec *hypervisor.VMRecord, sockPath string) (int, error) {
-			vmCfg := buildVMConfig(rec, hypervisor.ConsoleSockPath(rec.RunDir), ch.EffectiveCPUs(&rec.Config.Config))
+			vmCfg := buildVMConfig(rec, hypervisor.ConsoleSockPath(rec.RunDir), hypervisor.PlacementCPUs(&rec.Config.Config))
 			args := buildCLIArgs(vmCfg, sockPath)
 			ch.saveCmdline(ctx, rec, args)
 			return ch.launchProcess(ctx, rec, args, rec.ResolvedNetnsPath(), false)

--- a/hypervisor/start.go
+++ b/hypervisor/start.go
@@ -175,15 +175,6 @@ func (b *Backend) AbortLaunch(ctx context.Context, pid int, sockPath, runDir str
 	CleanupRuntimeFiles(ctx, runDir, runtimeFiles)
 }
 
-// PlacementCPUs resolves the host cores an explicit cpuset placement gives this VM alone; nil means none and the machine fence, not cocoon, bounds its threads.
-func PlacementCPUs(cfg *types.Config) []int {
-	cpus, err := cgroup.ParseCPUList(cfg.CPUSetCPUs)
-	if err != nil {
-		return nil
-	}
-	return cpus
-}
-
 func raiseVMMRlimits(ctx context.Context) {
 	logger := log.WithFunc("hypervisor.raiseVMMRlimits")
 	inf := unix.Rlimit{Cur: unix.RLIM_INFINITY, Max: unix.RLIM_INFINITY}

--- a/hypervisor/start.go
+++ b/hypervisor/start.go
@@ -170,14 +170,18 @@ func (b *Backend) ArmCPUQuota(id string, cfg *types.Config) error {
 	return nil
 }
 
-// EffectiveCPUs resolves the host cpu set a VM under this backend may run on: explicit placement over the machine fence.
-func (b *Backend) EffectiveCPUs(cfg *types.Config) []int {
-	return cgroup.EffectiveCPUs(cfg.CPUSetCPUs, b.Conf.CgroupCPUFence())
-}
-
 func (b *Backend) AbortLaunch(ctx context.Context, pid int, sockPath, runDir string, runtimeFiles []string) {
 	_ = utils.TerminateProcess(ctx, pid, b.Conf.BinaryName(), sockPath, b.Conf.TerminateGracePeriod())
 	CleanupRuntimeFiles(ctx, runDir, runtimeFiles)
+}
+
+// PlacementCPUs resolves the host cores an explicit cpuset placement gives this VM alone; nil means none and the machine fence, not cocoon, bounds its threads.
+func PlacementCPUs(cfg *types.Config) []int {
+	cpus, err := cgroup.ParseCPUList(cfg.CPUSetCPUs)
+	if err != nil {
+		return nil
+	}
+	return cpus
 }
 
 func raiseVMMRlimits(ctx context.Context) {

--- a/hypervisor/utils.go
+++ b/hypervisor/utils.go
@@ -294,10 +294,7 @@ func ValidateHostCPU(cpu int) error {
 
 // PlacementCPUs resolves the host cores an explicit cpuset placement gives this VM alone; nil means none and the machine fence, not cocoon, bounds its threads.
 func PlacementCPUs(cfg *types.Config) []int {
-	cpus, err := cgroup.ParseCPUList(cfg.CPUSetCPUs)
-	if err != nil {
-		return nil
-	}
+	cpus, _ := cgroup.ParseCPUList(cfg.CPUSetCPUs)
 	return cpus
 }
 

--- a/hypervisor/utils.go
+++ b/hypervisor/utils.go
@@ -292,6 +292,15 @@ func ValidateHostCPU(cpu int) error {
 	return nil
 }
 
+// PlacementCPUs resolves the host cores an explicit cpuset placement gives this VM alone; nil means none and the machine fence, not cocoon, bounds its threads.
+func PlacementCPUs(cfg *types.Config) []int {
+	cpus, err := cgroup.ParseCPUList(cfg.CPUSetCPUs)
+	if err != nil {
+		return nil
+	}
+	return cpus
+}
+
 // ValidateSnapshotIntegrity asserts the sidecar is valid and every snapshot-resident disk is present; layers are shared blobs.
 func ValidateSnapshotIntegrity(srcDir string, sidecar []*types.StorageConfig) error {
 	if err := types.ValidateStorageConfigs(sidecar); err != nil {

--- a/hypervisor/utils_test.go
+++ b/hypervisor/utils_test.go
@@ -19,6 +19,25 @@ func TestHostCPUCountIgnoresAffinityMask(t *testing.T) {
 	}
 }
 
+func TestPlacementCPUs(t *testing.T) {
+	tests := []struct {
+		name   string
+		cpuset string
+		want   []int
+	}{
+		{name: "explicit placement parses", cpuset: "2-3", want: []int{2, 3}},
+		{name: "no placement is no pin", cpuset: ""},
+		{name: "malformed list is no pin", cpuset: "0-"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PlacementCPUs(&types.Config{CPUSetCPUs: tt.cpuset}); !slices.Equal(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestValidateSnapshotIntegrity(t *testing.T) {
 	dir := t.TempDir()
 	mustWrite := func(name string) {


### PR DESCRIPTION
## The defect

`queueAffinity` mapped virtio-blk queue *i* onto host CPU *i* whenever a VM had
no cpuset, and Cloud Hypervisor turns `queue_affinity` into a hard
`sched_setaffinity` on each queue's worker thread. Since guest queue indices
start at 0 for every VM, every VM on a host emitted the identical mapping:

```
--disk path=.../cow.raw,direct=on,...,num_queues=8,queue_size=512,\
queue_affinity=[0@[0],1@[1],2@[2],3@[3],4@[4],5@[5],6@[6],7@[7]],serial=cocoon-cow
```

Every 8-vCPU VM's COW queue threads therefore land on host CPUs 0-7, however
many cores the host has, while the vCPU threads stay unpinned — so the disk I/O
half of the fleet is squeezed onto a fixed handful of cores.

The `allowed` clamp from #185 does not cover this: it resolves
`cmp.Or(placement, fence)`, and the `cgroup_cpus` fence is machine-wide (it is
written to the parent slice, shared by every scope). Falling back to it just
relocates the pile-up onto the fence's first cores. Only an explicit per-VM
`cpuset_cpus` names a core set this VM owns alone.

## The change

- Queue affinity comes from the VM's own placement only. No placement, no
  affinity: the scheduler places the queue threads, and the cgroup cpuset still
  bounds them, so nothing is lost in containment.
- With a placement, queues round-robin over that VM's cores, unchanged.
- Clone and restore delete the snapshot's `queue_affinity` before re-deriving,
  so a source host's mapping cannot survive onto a node that does not want it.
- `cgroup.EffectiveCPUs` existed only to feed this path and its fence fallback
  was the defect, so it is gone; `hypervisor.PlacementCPUs` replaces it.

Read-only disks and single-vCPU VMs are unaffected (they never got affinity).

## Evidence

384-core / 1.5 TB bare-metal host, isolated cocoon root, 24 concurrent 8-vCPU
sandboxes claimed cold, then 8 in-guest `dd oflag=direct` writers per sandbox.
The two arms differ only in the `cocoon` binary; interleaved A-B-B-A, 3 rounds
per shape, 0 failures.

Thread placement, from `/proc/<pid>/task/*/status`:

| thread | before | after |
| --- | --- | --- |
| COW disk `_disk1_q0..q7` | `0,1,2,3,4,5,6,7` | `0-383` |
| `vcpu0..7` | `0-383` | `0-383` |
| read-only layer `_disk0_q*` | `0-383` | `0-383` |

Per-CPU busy% sampled inside the I/O phase — identical in all six runs of each
arm:

| | cpu0-7 | cpu8-383 |
| --- | --- | --- |
| before | **96.1-99.4%** | 4.3-6.4% |
| after | 19-26% | 27-30% |

Throughput, medians over 6 runs per arm:

| shape | before | after | delta | A/A spread |
| --- | --- | --- | --- | --- |
| 4k, 8 writers | 377.2 MiB/s | **968.9 MiB/s** | **2.57x** | 27 |
| 4k io wall | 8145.5 ms | 3173.7 ms | -4972 ms | 567 ms |
| 1M, 8 writers | 3882.5 MiB/s | 3895.6 MiB/s | +0.3% | 27 |
| 24 cold claims p50 | 912.0 ms | 902.6 ms | -9.3 ms | 36.7 ms |

So the win is on IOPS-shaped guest I/O, where the pinned cores were the
constraint. Where the device is the limit (1M blocks) or the queues are idle
(cold boot) there is no difference, and none is claimed.

Hot path: the claim path does strictly less work — an unplaced VM no longer
allocates or formats a per-queue mapping.

## Tests

- `TestQueueAffinityFollowsPlacement` — no placement yields no affinity; a
  single queue is never pinned; a placement round-robins over its cores.
- `TestDiskCLIArgQueueAffinity` — the `--disk` argument carries no
  `queue_affinity` for an unplaced VM, and renders one host cpu per queue for a
  placed one.
- `TestPatchCHConfig_QueueAffinity` — a snapshot's stale mapping is dropped when
  the target has no placement, re-derived when it has one, and dropped from a
  read-only disk either way.
- `TestRestoreAndResumeCloneHotplugsByRoleWithPlacement` — both clone hot-plug
  sites feed the placement through to the disk they add.
- `TestPlacementCPUs` — the machine fence no longer reaches this path; only the
  VM's own `cpuset_cpus` does.

Each assertion was checked by reverting the code it guards. Gates: `make lint`
and `make fmt-check` clean on linux and darwin, `asl` clean on both, and
`go test -race -count=1 ./...` green (35 packages).

