### PR TITLE
fix: a listening API socket is not a launched VM; reject an invalid queue size

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -60,7 +60,7 @@ type Config struct {
 	DNS string `json:"dns" mapstructure:"dns"`
 	// NetScope keys this installation's host network families (bridge TAPs <scope><vmid8>-<nic>, CNI netns <scope>-<vmid>) so co-hosted installations never GC each other's; two alphanumerics, empty keeps the legacy bt / cocoon- names.
 	NetScope string `json:"net_scope,omitempty" mapstructure:"net_scope"`
-	// SocketWaitTimeoutSeconds: wait for the CH API socket after start. Default: 5; increase for slow storage.
+	// SocketWaitTimeoutSeconds: per-phase budget for the VMM to come up after start — the API socket appearing, then the VM reaching Running. Exceeding either kills the VMM. Default: 5; increase for slow storage.
 	SocketWaitTimeoutSeconds int `json:"socket_wait_timeout_seconds" mapstructure:"socket_wait_timeout_seconds"`
 	// TerminateGracePeriodSeconds: SIGTERM→SIGKILL window when force-killing CH. Default: 5.
 	TerminateGracePeriodSeconds int `json:"terminate_grace_period_seconds" mapstructure:"terminate_grace_period_seconds"`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -124,8 +124,8 @@ Applies to `cocoon vm create`, `cocoon vm run`, and `cocoon vm debug`:
 | `--memory`  | `1G`             | Memory size (e.g., 512M, 2G)                  |
 | `--storage` | `10G`            | COW disk size (e.g., 10G, 20G)                |
 | `--nics`    | `1`              | Number of network interfaces (0 = no network) |
-| `--queue-size` | `0` (default 512) | Virtio-net ring depth per queue (larger = better bulk throughput, smaller = better RPC latency; CH only, ignored by FC) |
-| `--disk-queue-size` | `0` (default 512) | Virtio-blk ring depth per device (CH only, ignored by FC) |
+| `--queue-size` | `0` (default 512) | Virtio-net ring depth per queue; a power of 2 no greater than 32768 (larger = better bulk throughput, smaller = better RPC latency; CH only, ignored by FC) |
+| `--disk-queue-size` | `0` (default 512) | Virtio-blk ring depth per device; a power of 2 no greater than 32768 (CH only, ignored by FC) |
 | `--network` | empty (default)  | CNI conflist name (empty = first conflist)     |
 | `--bridge`  | empty            | TAP-on-bridge mode (value is bridge device, e.g. `cni0`); mutually exclusive with `--network` |
 | `--user`    | `root`           | Guest username for cloud-init (cloudimg only)  |
@@ -153,8 +153,8 @@ Applies to `cocoon vm clone`:
 | ----------- | ------------------------ | ------------------------------------------------------- |
 | `--name`    | `cocoon-clone-<id>`      | VM name                                                 |
 | `--nics`    | inherit from snapshot    | Override NIC count at clone time; lets a 0-NIC snapshot clone with networking (CH hot-swaps NICs after restore) |
-| `--queue-size` | `0` (inherit)         | Virtio-net ring depth per queue (0 = inherit from snapshot) |
-| `--disk-queue-size` | `0` (inherit)    | Virtio-blk ring depth per device (0 = inherit from snapshot; CH only) |
+| `--queue-size` | `0` (inherit)         | Virtio-net ring depth per queue; a power of 2 no greater than 32768 (0 = inherit from snapshot) |
+| `--disk-queue-size` | `0` (inherit)    | Virtio-blk ring depth per device; a power of 2 no greater than 32768 (0 = inherit from snapshot; CH only) |
 | `--network` | empty (inherit)          | CNI conflist name (empty = inherit from source VM)       |
 | `--bridge`  | empty                    | TAP-on-bridge mode (value is bridge device); takes precedence over `--network` |
 | `--no-direct-io` | `false` (inherit)  | Disable O_DIRECT on writable disks (inherit from snapshot if not set) |

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -19,7 +19,10 @@ import (
 	"github.com/cocoonstack/cocoon/types"
 )
 
-const chStatePaused = "Paused"
+const (
+	chStateRunning = "Running"
+	chStatePaused  = "Paused"
+)
 
 // makeBodyFn builds a device endpoint's request body from the record reloaded under the ops lock.
 type makeBodyFn func(rec *hypervisor.VMRecord) any

--- a/hypervisor/cloudhypervisor/start.go
+++ b/hypervisor/cloudhypervisor/start.go
@@ -26,7 +26,7 @@ func (ch *CloudHypervisor) startOne(ctx context.Context, id string) error {
 			return ch.launchProcess(ctx, rec, args, rec.ResolvedNetnsPath(), false)
 		},
 		PostLaunch: func(ctx context.Context, rec *hypervisor.VMRecord, sockPath string, pid int) error {
-			if err := confirmVMBooted(ctx, utils.NewSocketHTTPClient(sockPath), pid, ch.conf.SocketWaitTimeout()); err != nil {
+			if err := confirmVMBooted(ctx, utils.NewSocketHTTPClientWithTimeout(sockPath, ch.conf.SocketWaitTimeout()), pid, ch.conf.SocketWaitTimeout()); err != nil {
 				return err
 			}
 			saveConsolePTY(ctx, rec.ID, rec.RunDir, sockPath, hypervisor.IsDirectBoot(rec.BootConfig))

--- a/hypervisor/cloudhypervisor/start.go
+++ b/hypervisor/cloudhypervisor/start.go
@@ -25,8 +25,8 @@ func (ch *CloudHypervisor) startOne(ctx context.Context, id string) error {
 			ch.saveCmdline(ctx, rec, args)
 			return ch.launchProcess(ctx, rec, args, rec.ResolvedNetnsPath(), false)
 		},
-		PostLaunch: func(ctx context.Context, rec *hypervisor.VMRecord, sockPath string, _ int) error {
-			if err := confirmVMMReady(ctx, utils.NewSocketHTTPClient(sockPath)); err != nil {
+		PostLaunch: func(ctx context.Context, rec *hypervisor.VMRecord, sockPath string, pid int) error {
+			if err := confirmVMBooted(ctx, utils.NewSocketHTTPClient(sockPath), pid, ch.conf.SocketWaitTimeout()); err != nil {
 				return err
 			}
 			saveConsolePTY(ctx, rec.ID, rec.RunDir, sockPath, hypervisor.IsDirectBoot(rec.BootConfig))

--- a/hypervisor/cloudhypervisor/start.go
+++ b/hypervisor/cloudhypervisor/start.go
@@ -9,6 +9,7 @@ import (
 	"github.com/projecteru2/core/log"
 
 	"github.com/cocoonstack/cocoon/hypervisor"
+	"github.com/cocoonstack/cocoon/utils"
 )
 
 func (ch *CloudHypervisor) Start(ctx context.Context, refs []string) ([]string, error) {
@@ -25,6 +26,9 @@ func (ch *CloudHypervisor) startOne(ctx context.Context, id string) error {
 			return ch.launchProcess(ctx, rec, args, rec.ResolvedNetnsPath(), false)
 		},
 		PostLaunch: func(ctx context.Context, rec *hypervisor.VMRecord, sockPath string, _ int) error {
+			if err := confirmVMMReady(ctx, utils.NewSocketHTTPClient(sockPath)); err != nil {
+				return err
+			}
 			saveConsolePTY(ctx, rec.ID, rec.RunDir, sockPath, hypervisor.IsDirectBoot(rec.BootConfig))
 			return nil
 		},

--- a/hypervisor/cloudhypervisor/utils.go
+++ b/hypervisor/cloudhypervisor/utils.go
@@ -249,6 +249,16 @@ func powerButton(ctx context.Context, hc *http.Client) error {
 	return err
 }
 
+// confirmVMMReady proves the VMM answers its API: cloud-hypervisor binds the API socket before it validates its launch config.
+func confirmVMMReady(ctx context.Context, hc *http.Client) error {
+	if _, err := utils.DoWithRetry(ctx, func() (*chVMInfoResponse, error) {
+		return getVMInfo(ctx, hc)
+	}); err != nil {
+		return fmt.Errorf("cloud-hypervisor did not answer vm.info after launch (see vm logs): %w", err)
+	}
+	return nil
+}
+
 // queryConsolePTY GETs vm.info for the virtio-console PTY path; "" if console is not in Pty mode.
 func queryConsolePTY(ctx context.Context, apiSocketPath string) (string, error) {
 	info, err := getVMInfo(ctx, utils.NewSocketHTTPClient(apiSocketPath))

--- a/hypervisor/cloudhypervisor/utils.go
+++ b/hypervisor/cloudhypervisor/utils.go
@@ -30,6 +30,8 @@ const (
 	chAPIBase     = "http://localhost/api/v1/"
 	apiSocketFlag = "--api-socket"
 
+	vmBootPollInterval = time.Millisecond
+
 	restoreModeCopy     = "copy"
 	restoreModeOnDemand = "ondemand"
 	restoreModeMmap     = "mmap"
@@ -249,12 +251,20 @@ func powerButton(ctx context.Context, hc *http.Client) error {
 	return err
 }
 
-// confirmVMMReady proves the VMM answers its API: cloud-hypervisor binds the API socket before it validates its launch config.
-func confirmVMMReady(ctx context.Context, hc *http.Client) error {
-	if _, err := utils.DoWithRetry(ctx, func() (*chVMInfoResponse, error) {
-		return getVMInfo(ctx, hc)
+// confirmVMBooted waits for Running: cloud-hypervisor serves its API socket before parsing the launch config and boots behind a second request.
+func confirmVMBooted(ctx context.Context, hc *http.Client, pid int, timeout time.Duration) error {
+	if err := utils.WaitFor(ctx, timeout, vmBootPollInterval, func() (bool, error) {
+		info, err := getVMInfo(ctx, hc)
+		switch {
+		case err == nil && info.State == chStateRunning:
+			return true, nil
+		case !utils.IsProcessAlive(pid):
+			return false, fmt.Errorf("cloud-hypervisor exited before the VM booted")
+		default:
+			return false, nil
+		}
 	}); err != nil {
-		return fmt.Errorf("cloud-hypervisor did not answer vm.info after launch (see vm logs): %w", err)
+		return fmt.Errorf("cloud-hypervisor never reported a running VM (see vm logs): %w", err)
 	}
 	return nil
 }

--- a/hypervisor/cloudhypervisor/utils.go
+++ b/hypervisor/cloudhypervisor/utils.go
@@ -30,7 +30,7 @@ const (
 	chAPIBase     = "http://localhost/api/v1/"
 	apiSocketFlag = "--api-socket"
 
-	vmBootPollInterval = time.Millisecond
+	vmBootPollInterval = 10 * time.Millisecond
 
 	restoreModeCopy     = "copy"
 	restoreModeOnDemand = "ondemand"
@@ -256,15 +256,15 @@ func confirmVMBooted(ctx context.Context, hc *http.Client, pid int, timeout time
 	if err := utils.WaitFor(ctx, timeout, vmBootPollInterval, func() (bool, error) {
 		info, err := getVMInfo(ctx, hc)
 		switch {
-		case err == nil && info.State == chStateRunning:
-			return true, nil
+		case err == nil:
+			return info.State == chStateRunning, nil
 		case !utils.IsProcessAlive(pid):
 			return false, fmt.Errorf("cloud-hypervisor exited before the VM booted")
 		default:
 			return false, nil
 		}
 	}); err != nil {
-		return fmt.Errorf("cloud-hypervisor never reported a running VM (see vm logs): %w", err)
+		return fmt.Errorf("wait for a running VM (see vm logs): %w", err)
 	}
 	return nil
 }

--- a/hypervisor/cloudhypervisor/utils_test.go
+++ b/hypervisor/cloudhypervisor/utils_test.go
@@ -87,7 +87,7 @@ func TestConfirmVMBootedWaitsOutACreatedVM(t *testing.T) {
 	if err == nil {
 		t.Fatal("confirmVMBooted accepted a VM that had been created but never booted")
 	}
-	if !strings.Contains(err.Error(), "never reported a running VM") {
+	if !strings.Contains(err.Error(), "wait for a running VM") {
 		t.Errorf("err = %v, want the unbooted VM named", err)
 	}
 }

--- a/hypervisor/cloudhypervisor/utils_test.go
+++ b/hypervisor/cloudhypervisor/utils_test.go
@@ -1,6 +1,7 @@
 package cloudhypervisor
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -8,7 +9,9 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/cocoonstack/cocoon/hypervisor"
 	"github.com/cocoonstack/cocoon/utils"
@@ -65,6 +68,32 @@ func TestSaveConsolePTYSkipsUEFI(t *testing.T) {
 
 	if utils.FileExists(hypervisor.ConsolePTYPath(runDir)) {
 		t.Error("console.pty written for a UEFI boot")
+	}
+}
+
+func TestConfirmVMMReadyAcceptsAnAnsweringVMM(t *testing.T) {
+	sockPath := serveVMInfo(t, "/dev/pts/7")
+
+	if err := confirmVMMReady(t.Context(), utils.NewSocketHTTPClient(sockPath)); err != nil {
+		t.Fatalf("confirmVMMReady: %v", err)
+	}
+}
+
+func TestConfirmVMMReadyRejectsASocketNothingServes(t *testing.T) {
+	sockPath := serveVMInfo(t, "/dev/pts/7")
+	if err := os.Remove(sockPath); err != nil {
+		t.Fatalf("remove %s: %v", sockPath, err)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	err := confirmVMMReady(ctx, utils.NewSocketHTTPClient(sockPath))
+
+	if err == nil {
+		t.Fatal("confirmVMMReady accepted a VMM that never answered vm.info")
+	}
+	if !strings.Contains(err.Error(), "did not answer vm.info") {
+		t.Errorf("err = %v, want the launch failure to name the unanswered vm.info", err)
 	}
 }
 

--- a/hypervisor/cloudhypervisor/utils_test.go
+++ b/hypervisor/cloudhypervisor/utils_test.go
@@ -1,13 +1,13 @@
 package cloudhypervisor
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -71,33 +71,54 @@ func TestSaveConsolePTYSkipsUEFI(t *testing.T) {
 	}
 }
 
-func TestConfirmVMMReadyAcceptsAnAnsweringVMM(t *testing.T) {
-	sockPath := serveVMInfo(t, "/dev/pts/7")
+func TestConfirmVMBootedAcceptsARunningVM(t *testing.T) {
+	sockPath := serveVMState(t, chStateRunning)
 
-	if err := confirmVMMReady(t.Context(), utils.NewSocketHTTPClient(sockPath)); err != nil {
-		t.Fatalf("confirmVMMReady: %v", err)
+	if err := confirmVMBooted(t.Context(), utils.NewSocketHTTPClient(sockPath), os.Getpid(), time.Second); err != nil {
+		t.Fatalf("confirmVMBooted: %v", err)
 	}
 }
 
-func TestConfirmVMMReadyRejectsASocketNothingServes(t *testing.T) {
-	sockPath := serveVMInfo(t, "/dev/pts/7")
+func TestConfirmVMBootedWaitsOutACreatedVM(t *testing.T) {
+	sockPath := serveVMState(t, "Created")
+
+	err := confirmVMBooted(t.Context(), utils.NewSocketHTTPClient(sockPath), os.Getpid(), 50*time.Millisecond)
+
+	if err == nil {
+		t.Fatal("confirmVMBooted accepted a VM that had been created but never booted")
+	}
+	if !strings.Contains(err.Error(), "never reported a running VM") {
+		t.Errorf("err = %v, want the unbooted VM named", err)
+	}
+}
+
+func TestConfirmVMBootedFailsFastWhenTheVMMIsGone(t *testing.T) {
+	sockPath := serveVMState(t, chStateRunning)
 	if err := os.Remove(sockPath); err != nil {
 		t.Fatalf("remove %s: %v", sockPath, err)
 	}
-	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
-	defer cancel()
 
-	err := confirmVMMReady(ctx, utils.NewSocketHTTPClient(sockPath))
+	err := confirmVMBooted(t.Context(), utils.NewSocketHTTPClient(sockPath), reapedPID(t), time.Second)
 
 	if err == nil {
-		t.Fatal("confirmVMMReady accepted a VMM that never answered vm.info")
+		t.Fatal("confirmVMBooted accepted a launch whose VMM had exited")
 	}
-	if !strings.Contains(err.Error(), "did not answer vm.info") {
-		t.Errorf("err = %v, want the launch failure to name the unanswered vm.info", err)
+	if !strings.Contains(err.Error(), "exited before the VM booted") {
+		t.Errorf("err = %v, want the dead VMM named", err)
 	}
 }
 
+func serveVMState(t *testing.T, state string) string {
+	t.Helper()
+	return serveCHAPI(t, chVMInfoResponse{State: state})
+}
+
 func serveVMInfo(t *testing.T, ptyPath string) string {
+	t.Helper()
+	return serveCHAPI(t, chVMInfoResponse{Config: chVMInfoConfig{Console: chRuntimeFile{Mode: "Pty", File: ptyPath}}})
+}
+
+func serveCHAPI(t *testing.T, resp chVMInfoResponse) string {
 	t.Helper()
 
 	sockDir, err := os.MkdirTemp("", "ch")
@@ -112,7 +133,6 @@ func serveVMInfo(t *testing.T, ptyPath string) string {
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/vm.info", func(w http.ResponseWriter, _ *http.Request) {
-		resp := chVMInfoResponse{Config: chVMInfoConfig{Console: chRuntimeFile{Mode: "Pty", File: ptyPath}}}
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			t.Errorf("encode vm.info: %v", err)
 		}
@@ -121,4 +141,13 @@ func serveVMInfo(t *testing.T, ptyPath string) string {
 	go srv.Serve(ln) //nolint:errcheck
 	t.Cleanup(func() { _ = srv.Close() })
 	return sockPath
+}
+
+func reapedPID(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("/usr/bin/true")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run /usr/bin/true: %v", err)
+	}
+	return cmd.Process.Pid
 }

--- a/types/vm.go
+++ b/types/vm.go
@@ -22,6 +22,8 @@ const (
 	TransitionStopUser       TransitionReason = "stop-user"
 	TransitionError          TransitionReason = "error"
 	TransitionUnexpectedExit TransitionReason = "unexpected-exit" // any exit outside a cocoon stop; an adopted process cannot report its cause
+
+	maxQueueSize = 32768
 )
 
 var (
@@ -66,11 +68,11 @@ func (cfg *VMConfig) Validate() error {
 	if cfg.Storage < 10<<30 {
 		return fmt.Errorf("--storage must be at least 10G, got %d", cfg.Storage)
 	}
-	if cfg.QueueSize < 0 {
-		return fmt.Errorf("--queue-size must be non-negative, got %d", cfg.QueueSize)
+	if err := validateQueueSize("--queue-size", cfg.QueueSize); err != nil {
+		return err
 	}
-	if cfg.DiskQueueSize < 0 {
-		return fmt.Errorf("--disk-queue-size must be non-negative, got %d", cfg.DiskQueueSize)
+	if err := validateQueueSize("--disk-queue-size", cfg.DiskQueueSize); err != nil {
+		return err
 	}
 	if cfg.Mergeable && (cfg.HugePages || cfg.SharedMemory) {
 		return fmt.Errorf("--mergeable needs plain private memory; drop --hugepages/--shared-memory")
@@ -163,4 +165,16 @@ func (v *VM) firstNIC() *NetworkConfig {
 		return nil
 	}
 	return v.NetworkConfigs[0]
+}
+
+func validateQueueSize(flag string, size int) error {
+	switch {
+	case size < 0:
+		return fmt.Errorf("%s must be non-negative, got %d", flag, size)
+	case size == 0:
+		return nil
+	case size > maxQueueSize || size&(size-1) != 0:
+		return fmt.Errorf("%s must be a power of 2 no greater than %d, got %d", flag, maxQueueSize, size)
+	}
+	return nil
 }

--- a/types/vm_test.go
+++ b/types/vm_test.go
@@ -85,6 +85,29 @@ func TestValidate(t *testing.T) {
 			modify: func(c *VMConfig) { c.DiskQueueSize = 0 },
 		},
 		{
+			name:    "queue size not a power of two",
+			modify:  func(c *VMConfig) { c.QueueSize = 7 },
+			wantErr: "--queue-size must be a power of 2 no greater than 32768, got 7",
+		},
+		{
+			name:    "queue size above the virtio ring bound",
+			modify:  func(c *VMConfig) { c.QueueSize = 65536 },
+			wantErr: "--queue-size must be a power of 2 no greater than 32768, got 65536",
+		},
+		{
+			name:    "disk queue size not a power of two",
+			modify:  func(c *VMConfig) { c.DiskQueueSize = 1000 },
+			wantErr: "--disk-queue-size must be a power of 2 no greater than 32768, got 1000",
+		},
+		{
+			name:   "queue size at the upper bound",
+			modify: func(c *VMConfig) { c.QueueSize = 32768 },
+		},
+		{
+			name:   "queue size default 512",
+			modify: func(c *VMConfig) { c.QueueSize = 512 },
+		},
+		{
 			name:   "valid username",
 			modify: func(c *VMConfig) { c.User = "deploy_user" },
 		},


### PR DESCRIPTION
Found on the 2026-09-12 isolated regression round (cocoon v0.6.4, CH v54.0.0 fork dev, EPYC/Debian 13), independently reproduced and traced to source.

## The defect

`cocoon vm run --queue-size 7` exits **0** and logs a successful start:

```
$ cocoon vm run --name q7 --network regnet --queue-size 7 ghcr.io/cocoonstack/cocoon/ubuntu:24.04
RC=0
INF VM created: 4YB67P4K5GMQTH7Z5CCJJRKT5X (name: q7)
WRN query console PTY for 4YB67P4K...: dial unix .../api.sock: connect: no such file or directory
INF started: 4YB67P4K5GMQTH7Z5CCJJRKT5X

$ cocoon vm logs q7 | tail -4
cloud-hypervisor: 0.001506s: <main> ERROR: Fatal error: ParsingConfig(Validation(InvalidQueueSize(7)))
  2: Queue size must be a power of 2 no greater than 32768: 7
```

The VM never booted. It is left `stopped (stale)` with an IP recorded.

Two independent causes:

**a. Missing validation.** `(*VMConfig).Validate` bounded `--queue-size` and `--disk-queue-size` only from below (`< 0`), so 7 and 65536 passed through into the CH `--net` argument verbatim. `docs/cli.md` documented the flag as "0 (default 512)" with no stated constraint, so a caller tuning ring depth reaches this on the documented surface.

**b. The launch-success oracle is wrong — the serious half.** cocoon's only proof that the VMM came up is one successful dial of the API socket (`WaitForSocket`, the last step of `LaunchVMProcess`). Cloud Hypervisor binds and listens on `--api-socket` *before* it validates the configuration it was launched with, so any config error that CH catches after listening is reported by cocoon as a successful start. This is not specific to `--queue-size`; it is the general shape.

## The fix

- `Validate` rejects a queue size that is not a power of two no greater than 32768 (0 still means the backend default), for both flags, and `docs/cli.md` states the constraint.
- The CH `PostLaunch` hook now requires an answered `vm.info` before the VM counts as started. A VMM that died after binding fails the launch and takes the existing `AbortLaunch` + `markFailedOperation` path instead of being recorded as running. The process log survives the abort, so `vm logs` still shows CH's own error.

Firecracker is unaffected: its `PostLaunch` already issues real API calls (`configureVM`) and propagates their errors. CH had no post-launch configuration round-trip — the config rides the command line — which is why nothing ever proved the VMM answered.

## Verification

```
go test ./types/ ./hypervisor/cloudhypervisor/ -count=1     ok, ok
make lint                                                   0 issues. (linux + darwin)
make fmt-check                                              rc=0
asl ./...                                                   no new findings
```

New tests: five `Validate` cases (non-power-of-2, above bound, disk variant, upper bound, 512) and two `confirmVMMReady` cases (answering VMM accepted; socket nothing serves rejected, naming the unanswered `vm.info`).
