### PR TITLE
fix: derive the boot cmdline at start, not once at create

### DIFF
--- a/hypervisor/cloudhypervisor/args.go
+++ b/hypervisor/cloudhypervisor/args.go
@@ -43,7 +43,7 @@ func DebugMemoryCLIArg(cfg *types.Config) string {
 	return memoryCLIArg(chMemory{Size: cfg.Memory, HugePages: cfg.HugePages, Shared: cfg.SharedMemory, Mergeable: cfg.Mergeable})
 }
 
-func buildVMConfig(rec *hypervisor.VMRecord, consoleSockPath string, placement []int) *chVMConfig {
+func buildVMConfig(rec *hypervisor.VMRecord, consoleSockPath string, placement []int, dnsServers []string) *chVMConfig {
 	cpu := rec.Config.CPU
 	mem := rec.Config.Memory
 
@@ -79,7 +79,7 @@ func buildVMConfig(rec *hypervisor.VMRecord, consoleSockPath string, placement [
 			cfg.Payload = &chPayload{
 				Kernel:    boot.KernelPath,
 				Initramfs: boot.InitrdPath,
-				Cmdline:   boot.Cmdline,
+				Cmdline:   buildCmdline(rec.StorageConfigs, rec.NetworkConfigs, rec.Config.Name, dnsServers),
 			}
 		case boot.FirmwarePath != "":
 			cfg.Payload = &chPayload{Firmware: boot.FirmwarePath}

--- a/hypervisor/cloudhypervisor/args_test.go
+++ b/hypervisor/cloudhypervisor/args_test.go
@@ -22,7 +22,7 @@ func TestMemoryCLIArg(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rec := &hypervisor.VMRecord{VM: types.VM{Config: types.VMConfig{Config: tt.cfg}}}
-			args := buildCLIArgs(buildVMConfig(rec, "", nil), "api.sock")
+			args := buildCLIArgs(buildVMConfig(rec, "", nil, nil), "api.sock")
 			i := slices.Index(args, "--memory")
 			if i < 0 || i+1 >= len(args) || args[i+1] != tt.want {
 				t.Fatalf("memory arg not %q (args: %s)", tt.want, strings.Join(args, " "))
@@ -65,7 +65,7 @@ func TestWatchdogPolicy(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			rec := &hypervisor.VMRecord{VM: types.VM{Config: types.VMConfig{Config: types.Config{NoWatchdog: tt.noWatchdog}}}}
-			if got := buildVMConfig(rec, "", nil).Watchdog; got != tt.want {
+			if got := buildVMConfig(rec, "", nil, nil).Watchdog; got != tt.want {
 				t.Fatalf("Watchdog = %v, want %v", got, tt.want)
 			}
 		})
@@ -94,7 +94,7 @@ func TestBalloonPolicy(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			rec := &hypervisor.VMRecord{VM: types.VM{Config: types.VMConfig{Config: types.Config{Memory: 1 << 30, NoBalloon: tt.noBalloon}}}}
-			got := buildVMConfig(rec, "", nil).Balloon
+			got := buildVMConfig(rec, "", nil, nil).Balloon
 			if tt.wantSize == 0 {
 				if got != nil {
 					t.Fatalf("balloon = %+v, want none", got)
@@ -108,6 +108,38 @@ func TestBalloonPolicy(t *testing.T) {
 				t.Errorf("balloon size = %d, want %d", got.Size, tt.wantSize)
 			}
 		})
+	}
+}
+
+func TestCmdlineFollowsTheLiveNICs(t *testing.T) {
+	rec := &hypervisor.VMRecord{
+		VM: types.VM{
+			Config: types.VMConfig{Name: "vm1", Config: types.Config{CPU: 2, Memory: 1 << 30}},
+			StorageConfigs: []*types.StorageConfig{
+				{Path: "/run/layer0.erofs", RO: true, Role: types.StorageRoleLayer, Serial: "l0"},
+				{Path: "/run/cow.raw", Role: types.StorageRoleCOW, Serial: hypervisor.CowSerial},
+			},
+			NetSetup: types.NetSetup{NetworkConfigs: []*types.NetworkConfig{
+				{TAP: "tapvm1-0", MAC: "9a:29:2c:4b:27:e4", Network: &types.Network{IP: "10.211.0.134", Gateway: "10.211.0.1", Prefix: 22}},
+			}},
+		},
+		BootConfig: &types.BootConfig{
+			KernelPath: "/run/vmlinuz",
+			InitrdPath: "/run/initrd.img",
+			Cmdline:    "console=hvc0 loglevel=3 boot=cocoon-overlay cocoon.layers=l0 cocoon.cow=cow clocksource=kvm-clock rw net.ifnames=0 cocoon.hostname=vm1 ip=10.211.0.20::10.211.0.1:255.255.252.0:vm1:eth0:off",
+		},
+	}
+
+	cfg := buildVMConfig(rec, "", nil, nil)
+
+	if cfg.Payload == nil {
+		t.Fatal("no payload built for a direct-boot record")
+	}
+	if !strings.Contains(cfg.Payload.Cmdline, "ip=10.211.0.134::10.211.0.1:255.255.252.0:vm1:eth0:off") {
+		t.Errorf("cmdline = %q, want the address the record now holds", cfg.Payload.Cmdline)
+	}
+	if strings.Contains(cfg.Payload.Cmdline, "10.211.0.20") {
+		t.Errorf("cmdline = %q, still replays the address the VM was created with", cfg.Payload.Cmdline)
 	}
 }
 

--- a/hypervisor/cloudhypervisor/start.go
+++ b/hypervisor/cloudhypervisor/start.go
@@ -2,6 +2,7 @@ package cloudhypervisor
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"syscall"
@@ -19,7 +20,11 @@ func (ch *CloudHypervisor) startOne(ctx context.Context, id string) error {
 	return ch.StartSequence(ctx, id, hypervisor.StartSpec{
 		RuntimeFiles: runtimeFiles,
 		Launch: func(ctx context.Context, rec *hypervisor.VMRecord, sockPath string) (int, error) {
-			vmCfg := buildVMConfig(rec, hypervisor.ConsoleSockPath(rec.RunDir), hypervisor.PlacementCPUs(&rec.Config.Config))
+			dns, err := ch.conf.DNSServers()
+			if err != nil {
+				return 0, fmt.Errorf("parse DNS servers: %w", err)
+			}
+			vmCfg := buildVMConfig(rec, hypervisor.ConsoleSockPath(rec.RunDir), hypervisor.PlacementCPUs(&rec.Config.Config), dns)
 			args := buildCLIArgs(vmCfg, sockPath)
 			ch.saveCmdline(ctx, rec, args)
 			return ch.launchProcess(ctx, rec, args, rec.ResolvedNetnsPath(), false)

--- a/hypervisor/firecracker/start.go
+++ b/hypervisor/firecracker/start.go
@@ -51,6 +51,9 @@ func (fc *Firecracker) configureVM(ctx context.Context, hc *http.Client, rec *hy
 	}
 
 	if boot := rec.BootConfig; boot != nil {
+		if err := fc.setBootCmdline(boot, rec.StorageConfigs, rec.NetworkConfigs, rec.Config.Name); err != nil {
+			return err
+		}
 		if err := putBootSource(ctx, hc, fcBootSource{
 			KernelImagePath: boot.KernelPath,
 			InitrdPath:      boot.InitrdPath,


### PR DESCRIPTION
Found on the 2026-09-12 isolated regression round (cocoon v0.6.4, CH v54.0.0 fork dev, CNI `regnet` 10.211.0.0/22), reproduced in both directions and traced to source.

## The defect

After a NIC resize, a stop/start leaves the guest on the address it was created with while cocoon reports the new one.

```
$ cocoon vm run ubuntu:24.04 --name a --nics 1        # 10.211.0.129, pings, 0% loss
  /proc/<pid>/cmdline: ip=10.211.0.129::10.211.0.1:255.255.252.0:a:eth0:off:8.8.8.8:1.1.1.1
$ cocoon vm net a --nics 0                            # resized: before=1 after=0 removed=1
$ cocoon vm net a --nics 1                            # resized: before=0 after=1 added=1; new lease 10.211.0.134
$ cocoon vm stop a && cocoon vm start a

  vm list:        a  running ... 10.211.0.134
  ping 10.211.0.134:  100% packet loss
  guest eth0:         10.211.0.129   (host-local IPAM lists .129 as free)
```

Same class with a `--nics 0` VM resized to 1: after restart the NIC comes up with no IPv4 and the recorded address is unreachable.

## Root cause

The direct-boot kernel command line is materialised once, at Create/Clone, and replayed verbatim on every later Start. `BootConfig.Cmdline` is assigned in exactly two places — `cloudhypervisor/create.go:43` and `clone.go:120` — and `vm net` (`hypervisor/netresize.go:159-173`) updates only `r.NetworkConfigs`, so the two halves of the record diverge permanently.

The asymmetry is visible inside the CH start path itself: `args.go:73-75` rebuilds `--net` from the live record, while `args.go:82,120-121` replays `--cmdline` from the stored string. Firecracker has the same shape — `firecracker/start.go` sends `BootArgs: boot.Cmdline` straight from the record.

## The fix

Both backends now rebuild the cmdline from the record they are about to launch, at the single place each one assembles its boot payload:

- CH: `buildVMConfig` takes the DNS servers and derives the payload cmdline from `rec.StorageConfigs` / `rec.NetworkConfigs`, so `--cmdline` and `--net` come from the same source of truth.
- FC: `configureVM` calls the backend's existing `setBootCmdline` before `PUT /boot-source`, which is what Create already uses.

Everything the cmdline encodes — layer serials, cow serial, hostname, per-NIC `ip=` — is derivable from the record, so nothing is lost by deriving it late. `buildVMConfig` has one caller (the fresh-boot start path); restore and clone build their payloads elsewhere and are untouched.

## Verification

`TestCmdlineFollowsTheLiveNICs` builds a record whose stored cmdline carries `ip=10.211.0.20` and whose NICs carry `10.211.0.134`, and asserts the built payload follows the record. Confirmed it bites — with the old `Cmdline: boot.Cmdline` restored:

```
--- FAIL: TestCmdlineFollowsTheLiveNICs (0.00s)
    args_test.go:139: cmdline = "... ip=10.211.0.20::10.211.0.1:255.255.252.0:vm1:eth0:off", want the address the record now holds
    args_test.go:142: cmdline = "... ip=10.211.0.20::...", still replays the address the VM was created with
```

```
go test ./hypervisor/... ./cmd/... -count=1     all ok
make lint                                       0 issues. (linux + darwin)
make fmt-check                                  rc=0
```
