### PR TITLE
fix: reject a --from-dir snapshot whose raw COW is not the recorded size

### DIFF
--- a/cmd/vm/run.go
+++ b/cmd/vm/run.go
@@ -4,6 +4,8 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"slices"
 	"sync"
 	"time"
@@ -228,6 +230,9 @@ func (h Handler) restoreFromDir(ctx context.Context, cmd *cobra.Command, conf *c
 	if err != nil {
 		return fmt.Errorf("load envelope: %w", err)
 	}
+	if err = verifyFromDirCOW(dir, cfg); err != nil {
+		return err
+	}
 	hyper, vm, err := cmdcore.FindVM(ctx, conf, vmRef)
 	if err != nil {
 		return fmt.Errorf("find VM %s: %w", vmRef, err)
@@ -272,6 +277,9 @@ func (h Handler) cloneFromDir(ctx context.Context, cmd *cobra.Command, conf *con
 	cfg, err := snapshot.ReadSnapshotEnvelope(dir)
 	if err != nil {
 		return fmt.Errorf("load envelope: %w", err)
+	}
+	if err = verifyFromDirCOW(dir, cfg); err != nil {
+		return err
 	}
 	// Local copy keeps backend flip from leaking to the caller's shared *config.Config.
 	localConf := *conf
@@ -580,6 +588,18 @@ func prereserveVM(ctx context.Context, hyper hypervisor.Hypervisor, vmID string,
 		return nil, nil, fmt.Errorf("reserve VM record: %w", err)
 	}
 	return func() { r.RollbackCreate(ctx, vmID, vmCfg.Name) }, unlock, nil
+}
+
+func verifyFromDirCOW(dir string, cfg types.SnapshotConfig) error {
+	st, err := os.Stat(filepath.Join(dir, hypervisor.COWRawFileName))
+	if err != nil || cfg.Storage <= 0 {
+		return nil
+	}
+	if st.Size() != cfg.Storage {
+		return fmt.Errorf("%s in %s is %d bytes but the envelope records %d: use `snapshot export --to-dir`, or `snapshot import` the exported tar — a third-party tar drops cocoon's sparse records and rebuilds a short, shifted disk",
+			hypervisor.COWRawFileName, dir, st.Size(), cfg.Storage)
+	}
+	return nil
 }
 
 func snapshotSource(cmd *cobra.Command, args []string, baseArgs int) (fromDir, snapRef string, err error) {

--- a/cmd/vm/run_test.go
+++ b/cmd/vm/run_test.go
@@ -1,10 +1,13 @@
 package vm
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/cocoonstack/cocoon/config"
+	"github.com/cocoonstack/cocoon/hypervisor"
 	"github.com/cocoonstack/cocoon/types"
 )
 
@@ -47,5 +50,48 @@ func TestCloneNICPlan(t *testing.T) {
 				t.Fatalf("plan = (%d, %d), want (%d, %d)", init, resize, tt.wantInit, tt.wantResize)
 			}
 		})
+	}
+}
+
+func TestVerifyFromDirCOWRejectsAShortRawDisk(t *testing.T) {
+	tests := []struct {
+		name    string
+		size    int64
+		storage int64
+		wantErr bool
+	}{
+		{"standard tar rebuilt a short cow", 78 << 20, 10 << 30, true},
+		{"cocoon export keeps the apparent size", 10 << 30, 10 << 30, false},
+		{"envelope records no storage", 78 << 20, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			f, err := os.Create(filepath.Join(dir, hypervisor.COWRawFileName))
+			if err != nil {
+				t.Fatalf("create cow: %v", err)
+			}
+			if err = f.Truncate(tt.size); err != nil {
+				t.Fatalf("truncate cow: %v", err)
+			}
+			if err = f.Close(); err != nil {
+				t.Fatalf("close cow: %v", err)
+			}
+
+			err = verifyFromDirCOW(dir, types.SnapshotConfig{Config: types.Config{Storage: tt.storage}})
+
+			if tt.wantErr && err == nil {
+				t.Fatal("accepted a cow.raw the envelope says is bigger")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("rejected a valid export: %v", err)
+			}
+		})
+	}
+}
+
+func TestVerifyFromDirCOWSkipsACloudimgOverlay(t *testing.T) {
+	if err := verifyFromDirCOW(t.TempDir(), types.SnapshotConfig{Config: types.Config{Storage: 10 << 30}}); err != nil {
+		t.Fatalf("rejected a dir with no raw cow: %v", err)
 	}
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -232,7 +232,7 @@ When FILE is omitted, data is read from stdin. This enables piping: `cocoon snap
 
 ### Direct Clone / Restore From a Directory
 
-`vm clone --from-dir DIR` and `vm restore --from-dir DIR` accept any directory containing a `snapshot.json` envelope (output of `snapshot export --to-dir`, or an extracted `.tar`). The snapshot does not need to be in the local snapshot DB:
+`vm clone --from-dir DIR` and `vm restore --from-dir DIR` accept a directory produced by `snapshot export --to-dir`. Do not unpack an `export -o file.tar` with a third-party tar and pass the result: cocoon stores sparse disks with private pax records that only its own extractor understands, so another tar rebuilds a short, content-shifted disk. To go through a tar, use `snapshot import`. The snapshot does not need to be in the local snapshot DB:
 
 ```bash
 # Build a portable snapshot dir, ship it, clone from it:


### PR DESCRIPTION
Found on the 2026-09-12 isolated regression round (cocoon v0.6.4, GNU tar 1.35), independently reproduced with a fresh VM and verified against source.

## The defect

`vm clone --from-dir` / `vm restore --from-dir` accept a snapshot directory whose `cow.raw` was unpacked by a standard tar. Both exit 0 with no warning; the guest then reads wrong data and logs EXT4-fs checksum errors. A same-lineage restore needs no `--force`, so an ordinary VM can be corrupted in place.

```
guest marker before:  sha256 6590af0f13833018be35257926dddee4d8a2e80a8b3f53ccbb7f084985037825
after restore:        wrong content, EXT4-fs checksum errors
cow.raw:              78 MB on disk for a 10 GiB disk
```

## Root cause

`utils/tar_sparse_linux.go:63-67` writes a sparse disk with `hdr.Size = dataSize` (data bytes only) and stashes the real length and hole map in the **private** pax keywords `COCOON.sparse.size` / `COCOON.sparse.map`. Only cocoon's `ExtractTar` reconstructs the file (`utils/tar.go:73-85`, `extractFileSparse` at `:108-134`: `Truncate(realSize)`, then seek+copy per segment). Any other tar ignores the unknown keywords and writes a file that is both truncated to `dataSize` and content-shifted — every byte after the first hole lands at the wrong offset.

Nothing downstream notices: `ValidateSnapshotIntegrity` (`hypervisor/utils.go:296-315`) only `os.Stat`s each disk, so a 78 MB file standing in for a 10 GiB disk passes.

And `docs/cli.md` invited exactly this: `--from-dir` accepts "output of `snapshot export --to-dir`, **or an extracted `.tar`**". There is no first-party command that unpacks an export tar into a directory, so a reader following that sentence reaches for GNU tar.

This is not a regression. The sparse pax writer landed in v0.1.6 (2026-03-02) and `--from-dir` in v0.3.9 (2026-04-30), so the hazard existed from the day the flag shipped; the doc sentence that invites it was added in v0.5.0 (2026-07-10).

## Scope — the mainstream paths were never affected

| path | tar | verdict |
|---|---|---|
| `vm clone SNAPSHOT` / `vm restore VM SNAP` from the store | cocoon writer → cocoon `ExtractTar` (`hypervisor/clone.go:41`, `restore.go:242`) | correct |
| `snapshot export --to-dir D` → `clone --from-dir D` | no tar at all | correct |
| `snapshot export -o x.tar` → `snapshot import x.tar` | cocoon writer → cocoon `ExtractTar` (`snapshot/localfile/import.go:46`) | correct |
| `snapshot export -o x.tar` → **third-party tar -x** → `--from-dir` | cocoon writer, foreign reader | **corrupts** |

Covered by `TestExportImport_Roundtrip`, `TestExport_ImportRoundtrip` and `TestExportToDir_RoundTrip`.

## The fix

- `docs/cli.md` stops offering the broken sequence and names the two supported flows.
- Both `--from-dir` entry points cross-check `cow.raw`'s apparent size against the `Storage` the envelope records, right where an untrusted directory enters. A directory rebuilt by another tar now fails with an error that says which flow to use instead. A cloudimg overlay (no `cow.raw`) and an envelope with no recorded storage are skipped.

The check sits at the CLI boundary rather than in `ValidateSnapshotIntegrity` because that function is also on the trusted store path and is reached through a fixed callback signature in the Firecracker backend.

## Verification

```
go test ./cmd/... -count=1     all ok
make lint                      0 issues. (linux + darwin)
make fmt-check                 rc=0
```

New tests cover the short disk, a correct export, a zero-storage envelope, and a directory with no raw COW.
