### PR TITLE
fix(ch): wait for the vsock socket so vm run -o json carries it

### DIFF
--- a/hypervisor/cloudhypervisor/start.go
+++ b/hypervisor/cloudhypervisor/start.go
@@ -34,6 +34,9 @@ func (ch *CloudHypervisor) startOne(ctx context.Context, id string) error {
 			if err := confirmVMBooted(ctx, utils.NewSocketHTTPClientWithTimeout(sockPath, ch.conf.SocketWaitTimeout()), pid, ch.conf.SocketWaitTimeout()); err != nil {
 				return err
 			}
+			if err := hypervisor.WaitForSocket(ctx, hypervisor.VsockSockPath(rec.RunDir), pid, ch.conf.SocketWaitTimeout(), ch.conf.BinaryName()); err != nil {
+				return err
+			}
 			saveConsolePTY(ctx, rec.ID, rec.RunDir, sockPath, hypervisor.IsDirectBoot(rec.BootConfig))
 			return nil
 		},


### PR DESCRIPTION
`cocoon vm run -o json` usually omits `vsock_socket`. Found on the 2026-09-12 regression round, then A/B'd on hardware against the released binary.

## The defect

`cmd/vm/run.go:73-81` does re-inspect after Start, on purpose. `hypervisor/inspect.go` `ToVM` → `SetRunningSockets` gates the field on a live `utils.FileExists(<runDir>/vsock.uds)`. The start sequence never waited for that UDS — `hypervisor/start.go:159` waits for the API socket and CH's `PostLaunch` waited for the console PTY — and cloud-hypervisor creates `vsock.uds` asynchronously after launch, so the immediate post-start inspect loses the race.

It is a race, not an invariant absence: across the hardware round the released binary emitted the field in 1 of 30 runs.

## The fix

CH's `PostLaunch` waits for the socket with `hypervisor.WaitForSocket`, the helper the launch path already uses for the API socket, bounded by the same `SocketWaitTimeout` and failing fast if the VMM exits first. Four lines.

## What this does and does not claim

It makes `vsock_socket` deterministic in `vm run -o json`. It does **not** mean the guest agent is ready — those are different states about 2.4 s apart, and the hardware A/B measured exactly that: with the socket present and verified live (`test -S`) on every fixed-arm run, the first `vm exec` still failed with `dial agent: read CONNECT reply: EOF` and took 2390–2440 ms of retrying before the agent answered. The released binary is statistically identical at 2262–2475 ms, so nothing regressed — but a caller still has to retry `exec`, exactly as before. The value of the field is that a machine consumer no longer has to poll `vm list` to learn the path.

## Hardware A/B (cocoon-test2, EPYC 9Y24, Debian 13, CH fork dev v54.0.0)

Isolated cocoon root per arm; `cocoon-base` = v0.6.4 (6d63836d1), `cocoon-fixed` = this branch.

| | base | fixed |
|---|---|---|
| `vm run -o json` carrying `vsock_socket` | 0/10 in the A batch, 1/30 overall | 10/10, 31/31 overall, path verified as a live socket each time |
| `vm run` wall time, 15 runs, VM torn down between each | min 230 / median 247 / max 390 ms | min 243 / median 253 / max 333 ms |
| `vm clone -o json` / `vm restore -o json` carry the field | yes | yes (no regression) |

The added wait costs about 6 ms of median start latency.

## Verification

```
go test ./hypervisor/... -count=1     all ok
make lint                             0 issues. (linux + darwin)
make fmt-check                        rc=0
```

No new unit test: after review the change reduced to one call of an existing, already-exercised helper, so the evidence that the start path now waits is the hardware A/B above rather than a test of a wrapper that no longer exists.

Note for the reviewer: this touches CH's `PostLaunch`, as does #227. Whichever lands second needs a one-line rebase.
