### PR TITLE
fix: reject the CLI input three commands silently ignored

### DIFF
--- a/cmd/cliutil/cliutil.go
+++ b/cmd/cliutil/cliutil.go
@@ -35,16 +35,7 @@ func AddFormatFlag(cmd *cobra.Command) {
 // Format reads --format and rejects a value outside the flag's enum.
 func Format(cmd *cobra.Command) (string, error) {
 	format, _ := cmd.Flags().GetString("format")
-	return format, ValidateFormat(format)
-}
-
-func ValidateFormat(format string) error {
-	switch format {
-	case "", FormatTable, FormatJSON:
-		return nil
-	default:
-		return fmt.Errorf("--format %q is invalid: want %q or %q", format, FormatTable, FormatJSON)
-	}
+	return format, validateFormat(format)
 }
 
 func AddOutputFlag(cmd *cobra.Command) {
@@ -85,7 +76,7 @@ func OutputFormatted(cmd *cobra.Command, data any, tableFn TableFunc) error {
 }
 
 func OutputFormattedStr(format string, data any, tableFn TableFunc) error {
-	if err := ValidateFormat(format); err != nil {
+	if err := validateFormat(format); err != nil {
 		return err
 	}
 	if format == FormatJSON {
@@ -103,4 +94,13 @@ func FormatSize(bytes int64) string {
 
 func IsURL(ref string) bool {
 	return strings.HasPrefix(ref, "http://") || strings.HasPrefix(ref, "https://")
+}
+
+func validateFormat(format string) error {
+	switch format {
+	case "", FormatTable, FormatJSON:
+		return nil
+	default:
+		return fmt.Errorf("--format %q is invalid: want %q or %q", format, FormatTable, FormatJSON)
+	}
 }

--- a/cmd/cliutil/cliutil.go
+++ b/cmd/cliutil/cliutil.go
@@ -4,12 +4,18 @@ package cliutil
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
+)
+
+const (
+	FormatTable = "table"
+	FormatJSON  = "json"
 )
 
 // TableFunc renders the table body; the writer is flushed by the caller.
@@ -23,7 +29,22 @@ func CommandContext(cmd *cobra.Command) context.Context {
 }
 
 func AddFormatFlag(cmd *cobra.Command) {
-	cmd.Flags().StringP("format", "o", "table", `output format: "table" or "json"`)
+	cmd.Flags().StringP("format", "o", FormatTable, `output format: "table" or "json"`)
+}
+
+// Format reads --format and rejects a value outside the flag's enum.
+func Format(cmd *cobra.Command) (string, error) {
+	format, _ := cmd.Flags().GetString("format")
+	return format, ValidateFormat(format)
+}
+
+func ValidateFormat(format string) error {
+	switch format {
+	case "", FormatTable, FormatJSON:
+		return nil
+	default:
+		return fmt.Errorf("--format %q is invalid: want %q or %q", format, FormatTable, FormatJSON)
+	}
 }
 
 func AddOutputFlag(cmd *cobra.Command) {
@@ -56,13 +77,18 @@ func MaybeOutputJSON(cmd *cobra.Command, v any) (bool, error) {
 }
 
 func OutputFormatted(cmd *cobra.Command, data any, tableFn TableFunc) error {
-	format, _ := cmd.Flags().GetString("format")
+	format, err := Format(cmd)
+	if err != nil {
+		return err
+	}
 	return OutputFormattedStr(format, data, tableFn)
 }
 
-// OutputFormattedStr renders data as JSON when format=="json", else as a table via tableFn.
 func OutputFormattedStr(format string, data any, tableFn TableFunc) error {
-	if format == "json" {
+	if err := ValidateFormat(format); err != nil {
+		return err
+	}
+	if format == FormatJSON {
 		return OutputJSON(data)
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)

--- a/cmd/cliutil/cliutil_test.go
+++ b/cmd/cliutil/cliutil_test.go
@@ -1,0 +1,29 @@
+package cliutil
+
+import "testing"
+
+func TestValidateFormat(t *testing.T) {
+	tests := []struct {
+		format  string
+		wantErr string
+	}{
+		{"table", ""},
+		{"json", ""},
+		{"", ""},
+		{"yaml", `--format "yaml" is invalid: want "table" or "json"`},
+		{"JSON", `--format "JSON" is invalid: want "table" or "json"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.format, func(t *testing.T) {
+			err := ValidateFormat(tt.format)
+			switch {
+			case tt.wantErr == "" && err != nil:
+				t.Fatalf("ValidateFormat(%q) = %v, want nil", tt.format, err)
+			case tt.wantErr != "" && err == nil:
+				t.Fatalf("ValidateFormat(%q) = nil, want %q", tt.format, tt.wantErr)
+			case tt.wantErr != "" && err.Error() != tt.wantErr:
+				t.Fatalf("ValidateFormat(%q) = %q, want %q", tt.format, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/cliutil/cliutil_test.go
+++ b/cmd/cliutil/cliutil_test.go
@@ -15,14 +15,14 @@ func TestValidateFormat(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.format, func(t *testing.T) {
-			err := ValidateFormat(tt.format)
+			err := validateFormat(tt.format)
 			switch {
 			case tt.wantErr == "" && err != nil:
-				t.Fatalf("ValidateFormat(%q) = %v, want nil", tt.format, err)
+				t.Fatalf("validateFormat(%q) = %v, want nil", tt.format, err)
 			case tt.wantErr != "" && err == nil:
-				t.Fatalf("ValidateFormat(%q) = nil, want %q", tt.format, tt.wantErr)
+				t.Fatalf("validateFormat(%q) = nil, want %q", tt.format, tt.wantErr)
 			case tt.wantErr != "" && err.Error() != tt.wantErr:
-				t.Fatalf("ValidateFormat(%q) = %q, want %q", tt.format, err, tt.wantErr)
+				t.Fatalf("validateFormat(%q) = %q, want %q", tt.format, err, tt.wantErr)
 			}
 		})
 	}

--- a/cmd/images/manage.go
+++ b/cmd/images/manage.go
@@ -15,6 +15,9 @@ import (
 )
 
 func (h Handler) List(cmd *cobra.Command, _ []string) error {
+	if _, err := cliutil.Format(cmd); err != nil {
+		return err
+	}
 	ctx, conf := h.Init(cmd)
 	backends, err := cmdcore.InitImageBackends(ctx, conf)
 	if err != nil {

--- a/cmd/snapshot/handler.go
+++ b/cmd/snapshot/handler.go
@@ -49,6 +49,9 @@ func (h Handler) Save(cmd *cobra.Command, args []string) error {
 }
 
 func (h Handler) List(cmd *cobra.Command, _ []string) error {
+	if _, err := cliutil.Format(cmd); err != nil {
+		return err
+	}
 	ctx, conf := h.Init(cmd)
 	snapBackend, err := cmdcore.InitSnapshot(ctx, conf)
 	if err != nil {

--- a/cmd/vm/debug.go
+++ b/cmd/vm/debug.go
@@ -49,6 +49,9 @@ func (h Handler) Debug(cmd *cobra.Command, args []string) error {
 	if len(vmCfg.DataDisks) > 0 {
 		fmt.Fprintln(os.Stderr, "warning: --data-disk is ignored in debug mode (debug only prints the hypervisor launch command; data disks need PrepareDataDisks to materialize)")
 	}
+	if set := changedFlags(cmd, "nics", "queue-size", "network", "bridge"); len(set) > 0 {
+		fmt.Fprintf(os.Stderr, "warning: %s ignored in debug mode (debug only prints the hypervisor launch command; NIC attachment needs a prepared netns and TAP, so no --net or ip= is emitted)\n", strings.Join(set, "/"))
+	}
 
 	storageConfigs, boot, err := cmdcore.ResolveImage(ctx, backends, vmCfg)
 	if err != nil {
@@ -229,4 +232,14 @@ func printCommonCHArgs(s chDebugSpec) {
 		fmt.Print("  --watchdog \\\n")
 	}
 	fmt.Println("  --serial tty --console off")
+}
+
+func changedFlags(cmd *cobra.Command, names ...string) []string {
+	var set []string
+	for _, n := range names {
+		if cmd.Flags().Changed(n) {
+			set = append(set, "--"+n)
+		}
+	}
+	return set
 }

--- a/cmd/vm/debug_test.go
+++ b/cmd/vm/debug_test.go
@@ -1,0 +1,38 @@
+package vm
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestChangedFlagsNamesOnlyWhatTheUserSet(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().Int("nics", 1, "")
+	cmd.Flags().Int("queue-size", 0, "")
+	cmd.Flags().String("network", "", "")
+	cmd.Flags().String("bridge", "", "")
+	if err := cmd.Flags().Set("nics", "2"); err != nil {
+		t.Fatalf("set nics: %v", err)
+	}
+	if err := cmd.Flags().Set("bridge", "cni0"); err != nil {
+		t.Fatalf("set bridge: %v", err)
+	}
+
+	got := changedFlags(cmd, "nics", "queue-size", "network", "bridge")
+
+	want := []string{"--nics", "--bridge"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("changedFlags = %v, want %v", got, want)
+	}
+}
+
+func TestChangedFlagsIsEmptyWhenNothingIsSet(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().Int("nics", 1, "")
+
+	if got := changedFlags(cmd, "nics"); len(got) != 0 {
+		t.Fatalf("changedFlags = %v, want none for a default-valued flag", got)
+	}
+}

--- a/cmd/vm/run.go
+++ b/cmd/vm/run.go
@@ -625,6 +625,9 @@ func tapQueues(cpu int, useFC bool) int {
 }
 
 func initNetwork(ctx context.Context, conf *config.Config, vmID string, nics int, vmCfg *types.VMConfig, queues int, bridgeDev string) (network.Network, types.NetSetup, error) {
+	if nics < 0 {
+		return nil, types.NetSetup{}, fmt.Errorf("--nics must be non-negative, got %d", nics)
+	}
 	var netProvider network.Network
 	var err error
 	if bridgeDev != "" {

--- a/cmd/vm/run_test.go
+++ b/cmd/vm/run_test.go
@@ -95,3 +95,14 @@ func TestVerifyFromDirCOWSkipsACloudimgOverlay(t *testing.T) {
 		t.Fatalf("rejected a dir with no raw cow: %v", err)
 	}
 }
+
+func TestInitNetworkRejectsNegativeNICs(t *testing.T) {
+	_, _, err := initNetwork(t.Context(), &config.Config{}, "vm1", -1, &types.VMConfig{}, 2, "")
+
+	if err == nil {
+		t.Fatal("initNetwork accepted a negative --nics instead of rejecting it")
+	}
+	if !strings.Contains(err.Error(), "--nics must be non-negative, got -1") {
+		t.Errorf("err = %v, want the same rejection the clone path gives", err)
+	}
+}

--- a/cmd/vm/status.go
+++ b/cmd/vm/status.go
@@ -47,7 +47,10 @@ func (h Handler) List(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	format, _ := cmd.Flags().GetString("format")
+	format, err := cliutil.Format(cmd)
+	if err != nil {
+		return err
+	}
 	return statusOnce(ctx, hypers, nil, format, conf.CgroupParentDir())
 }
 
@@ -61,7 +64,10 @@ func (h Handler) Status(cmd *cobra.Command, args []string) error {
 	if eventMode && watchMode {
 		return fmt.Errorf("--event and --watch are mutually exclusive")
 	}
-	format, _ := cmd.Flags().GetString("format")
+	format, err := cliutil.Format(cmd)
+	if err != nil {
+		return err
+	}
 
 	hypers, hyperErr := cmdcore.InitAllHypervisors(ctx, conf)
 	if hyperErr != nil {
@@ -77,7 +83,7 @@ func (h Handler) Status(cmd *cobra.Command, args []string) error {
 	defer ticker.Stop()
 
 	if eventMode {
-		if format == "json" {
+		if format == cliutil.FormatJSON {
 			statusEventLoopJSON(ctx, hypers, args, watchCh, ticker.C)
 		} else {
 			statusEventLoop(ctx, hypers, args, watchCh, ticker.C)
@@ -105,7 +111,10 @@ func statusOnce(ctx context.Context, hypers []hypervisor.Hypervisor, filters []s
 }
 
 func renderVMList(vms []*types.VM, format, scopeDir string) error {
-	if format == "json" {
+	if err := cliutil.ValidateFormat(format); err != nil {
+		return err
+	}
+	if format == cliutil.FormatJSON {
 		if vms == nil {
 			vms = []*types.VM{}
 		}

--- a/cmd/vm/status.go
+++ b/cmd/vm/status.go
@@ -111,9 +111,6 @@ func statusOnce(ctx context.Context, hypers []hypervisor.Hypervisor, filters []s
 }
 
 func renderVMList(vms []*types.VM, format, scopeDir string) error {
-	if err := cliutil.ValidateFormat(format); err != nil {
-		return err
-	}
 	if format == cliutil.FormatJSON {
 		if vms == nil {
 			vms = []*types.VM{}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -296,6 +296,11 @@ Applies to `cocoon vm debug`:
 | `--cow`     |                      | COW disk path (default: auto-generated)             |
 | `--ch`      | `cloud-hypervisor`   | cloud-hypervisor binary path                        |
 
+`vm debug` prints the VMM launch command only. It does not prepare a netns or a
+TAP, so it emits no `--net` and no `ip=`, and `--nics`, `--queue-size`,
+`--network` and `--bridge` are ignored — setting any of them warns on stderr,
+like `--data-disk`.
+
 ### Console Flags
 
 | Flag             | Default  | Description                                       |


### PR DESCRIPTION
The three low-severity findings from the 2026-09-12 regression round, batched. All three are the same shape: a flag the CLI accepts and then ignores. None is new — the oldest predates v0.1.0.

## 1. `--format` with an out-of-enum value renders a table and exits 0

`cocoon vm list --format yaml` printed the normal table with rc=0. The flag is registered as an explicit two-value enum (`cliutil.go:25-27`), but dispatch was `if format == "json" { … }` with an unconditional table else-branch and no error path; `cmd/vm/status.go` repeated the shape, including a "No VMs found." early return that ran for any non-json value.

`ValidateFormat` now backs both the generic helper and `vm status` / `vm list`, and `""`/`table`/`json` stay accepted.

## 2. `--nics` accepts a negative value

`createVM` read the flag raw and handed it to `initNetwork`, whose `nics <= 0` branches folded any negative value into the no-network case: the CNI netns was prepared, no NIC specs were added, and the VM booted with empty `network_configs`. The clone path already rejected it (`cloneNICPlan`, `run.go:509-511`), so the two entry points disagreed.

The guard now sits in `initNetwork`, the funnel both paths go through, with the message `cloneNICPlan` already uses.

## 3. `vm debug` advertises network flags it cannot honour

`addVMFlags(debugCmd)` registers `--nics`, `--queue-size`, `--network` and `--bridge`, but the CH print path never touches NICs: `debug.go:180-181` calls `BuildBaseCmdline(..., nil /*networkConfigs*/, ...)`, and `hypervisor/utils.go:197-200` emits `net.ifnames=0` and `ip=` only for a non-empty NIC list — so `nil` means no `ip=` at all. `printCHDebug`/`printCommonCHArgs` never emit a `--net` line either, unlike the real builder at `cloudhypervisor/args.go:124`.

`vm debug` is a dry run: it prepares no netns and no TAP, so a printed `--net` would name a device that does not exist and the command still would not run. Rather than invent placeholder syntax, setting any of the four now warns on stderr — the convention this command already uses for `--data-disk` — and `docs/cli.md` states the limitation.

```
$ cocoon vm debug --nics 2 --bridge cni0 ubuntu:24.04
warning: --nics/--bridge ignored in debug mode (debug only prints the hypervisor launch command; NIC attachment needs a prepared netns and TAP, so no --net or ip= is emitted)
```

## Provenance

| finding | introduced | version |
|---|---|---|
| `vm debug` network flags | `7088721` command registration | v0.1.0 (2026-02-25) |
| `--nics` negative | `79ff681` netns lifecycle refactor | v0.1.0 (2026-02-26) |
| `--format` dispatch | `6341056` | v0.1.4 (2026-03-01) |

## Verification

```
go test ./cmd/... -count=1     all ok
make lint                      0 issues. (linux + darwin)
make fmt-check                 rc=0
asl ./...                      no new findings
```

New tests: `ValidateFormat` over the enum plus `yaml` and a case-variant; `initNetwork` rejecting `-1`; `changedFlags` naming only what the user set.
